### PR TITLE
Fix misplaced semi-colons in input types

### DIFF
--- a/.changeset/spicy-eyes-cough.md
+++ b/.changeset/spicy-eyes-cough.md
@@ -1,0 +1,5 @@
+---
+'@gqty/cli': patch
+---
+
+Fix misplaced semi-colons in input types

--- a/packages/cli/src/generate.ts
+++ b/packages/cli/src/generate.ts
@@ -643,29 +643,24 @@ export async function generate(
           if (fieldValue.__args) {
             const argsEntries = Object.entries(fieldValue.__args);
             let onlyNullableArgs = true;
-            const argTypes = argsEntries.reduce(
-              (acum, [argKey, argValue], index) => {
-                const argValueProps = parseSchemaType(argValue);
-                const connector = argValueProps.isNullable ? '?:' : ':';
+            const argTypes = argsEntries.reduce((acum, [argKey, argValue]) => {
+              const argValueProps = parseSchemaType(argValue);
+              const connector = argValueProps.isNullable ? '?:' : ':';
 
-                if (!argValueProps.isNullable) {
-                  onlyNullableArgs = false;
-                }
+              if (!argValueProps.isNullable) {
+                onlyNullableArgs = false;
+              }
 
-                const argTypeValue = parseArgType(argValueProps);
+              const argTypeValue = parseArgType(argValueProps);
 
-                acum += `${addDescription([
-                  typeName,
-                  fieldKey,
-                  argKey,
-                ])}${argKey}${connector} ${argTypeValue}`;
-                if (index < argsEntries.length - 1) {
-                  acum += '; ';
-                }
-                return acum;
-              },
-              ''
-            );
+              acum += `${addDescription([
+                typeName,
+                fieldKey,
+                argKey,
+              ])}${argKey}${connector} ${argTypeValue};\n`;
+
+              return acum;
+            }, '');
             const argsConnector = onlyNullableArgs ? '?:' : ':';
             finalType = `: (args${argsConnector} {${argTypes}}) => ${typeToReturn}`;
           } else {

--- a/packages/cli/test/generate.test.ts
+++ b/packages/cli/test/generate.test.ts
@@ -706,10 +706,10 @@ export interface Query {
     hello: Scalars['String'];
   }) => ScalarsEnums['String'];
   stringNullableWithArgs: (args: {
-    hello: Scalars['String']
+    hello: Scalars['String'];
     /**
      * @defaultValue \`\\"Hi\\"\`
-     */;
+     */
     helloTwo?: Maybe<Scalars['String']>;
   }) => Maybe<ScalarsEnums['String']>;
   stringNullableWithArgsArray: (args: {


### PR DESCRIPTION
Semi-colons are misplaced when the next input type contains descriptions.

![image](https://user-images.githubusercontent.com/85772/135572782-50378784-5b61-4e74-abc8-687795e04ed3.png)

This is caused by a missing line break in the generated code before formatting, prettier has a habit of treating these block comments as the same statement.