### PR TITLE
(fix) Field args that has defaultValue should not be mandatory.

### DIFF
--- a/.changeset/rich-pens-allow.md
+++ b/.changeset/rich-pens-allow.md
@@ -1,0 +1,5 @@
+---
+'@gqty/cli': minor
+---
+
+Fix generator: Argument is required only if it is non-null and does not have default value. Previously only checking if it is non-null.

--- a/packages/gqty/src/Schema/types.ts
+++ b/packages/gqty/src/Schema/types.ts
@@ -30,13 +30,26 @@ export type QueryFetcher = (
 export interface ParseSchemaTypeInfo {
   pureType: string;
   isNullable: boolean;
+  hasDefaultValue: boolean;
   isArray: boolean;
   nullableItems: boolean;
 }
 
-export function parseSchemaType(type: string): ParseSchemaTypeInfo {
+export interface FieldDescription {
+  description?: string | null;
+  deprecated?: string | null;
+  defaultValue?: string | null;
+}
+
+export type ArgsDescriptions = Record<
+    string,
+    Record<string, FieldDescription | undefined>
+    >;
+
+export function parseSchemaType(type: string, fieldDesc: FieldDescription | undefined = undefined): ParseSchemaTypeInfo {
   let isArray = false;
   let isNullable = true;
+  let hasDefaultValue = !!(fieldDesc && fieldDesc.defaultValue !== null);
   let pureType = type;
   let nullableItems = true;
   if (pureType.endsWith('!')) {
@@ -56,6 +69,7 @@ export function parseSchemaType(type: string): ParseSchemaTypeInfo {
   return {
     pureType,
     isNullable,
+    hasDefaultValue,
     isArray,
     nullableItems,
   };

--- a/packages/gqty/test/schema.test.ts
+++ b/packages/gqty/test/schema.test.ts
@@ -7,6 +7,7 @@ describe('parseSchemaType', () => {
     expect(info).toEqual<ParseSchemaTypeInfo>({
       pureType: 'String',
       isNullable: true,
+      hasDefaultValue: false,
       nullableItems: true,
       isArray: false,
     });
@@ -18,6 +19,7 @@ describe('parseSchemaType', () => {
     expect(info).toEqual<ParseSchemaTypeInfo>({
       pureType: 'String',
       isNullable: false,
+      hasDefaultValue: false,
       nullableItems: true,
       isArray: false,
     });
@@ -28,6 +30,7 @@ describe('parseSchemaType', () => {
     expect(info).toEqual<ParseSchemaTypeInfo>({
       pureType: 'String',
       isNullable: true,
+      hasDefaultValue: false,
       nullableItems: true,
       isArray: true,
     });
@@ -39,6 +42,7 @@ describe('parseSchemaType', () => {
     expect(info).toEqual<ParseSchemaTypeInfo>({
       pureType: 'String',
       isNullable: true,
+      hasDefaultValue: false,
       nullableItems: false,
       isArray: true,
     });


### PR DESCRIPTION
Per GraphQL spec(418), non-null object fields can be omitted if they supply a default value:

https://github.com/graphql/graphql-spec/pull/418

