### PR TITLE
Fix `usePaginatedQuery` example

### DIFF
--- a/internal/website/docs/react/fetching-data.mdx
+++ b/internal/website/docs/react/fetching-data.mdx
@@ -254,7 +254,7 @@ function Example() {
         nodes,
         pageInfo: { hasNextPage, endCursor },
       } = query.users({
-        input,
+        ...input,
       });
       return {
         nodes: getArrayFields(nodes, 'name'),


### PR DESCRIPTION
The `usePaginatedQuery` example was providing `input` to `query.users` without destructuring it's properties, leading to a failed GraphQL request.