### PR TITLE
subscriptions: don't force unsubscribe in unmounts

### DIFF
--- a/.changeset/honest-spies-agree.md
+++ b/.changeset/honest-spies-agree.md
@@ -1,0 +1,6 @@
+---
+'@gqty/subscriptions': patch
+---
+
+subscriptions: don't force unsubscribe in unmounts
+onSubscription: don't force unsubscribe in unmounts

--- a/.changeset/honest-spies-agree.md
+++ b/.changeset/honest-spies-agree.md
@@ -2,5 +2,4 @@
 '@gqty/subscriptions': patch
 ---
 
-subscriptions: don't force unsubscribe in unmounts
-onSubscription: don't force unsubscribe in unmounts
+Don't force unsubscribe in cleanup functions

--- a/packages/subscriptions/src/index.ts
+++ b/packages/subscriptions/src/index.ts
@@ -123,7 +123,7 @@ export function createSubscriptionsClient({
 
         function returnSub(operationId: string) {
           const unsubscribe = async () => {
-            await wsSubClient.unsubscribe(operationId, true);
+            await wsSubClient.unsubscribe(operationId);
             SubscriptionsSelections.delete(operationId);
           };
           SubscriptionsSelections.set(operationId, new Set(selections));

--- a/packages/subscriptions/src/index.ts
+++ b/packages/subscriptions/src/index.ts
@@ -148,7 +148,7 @@ export function createSubscriptionsClient({
         for (const selection of selections) {
           if (operationSelections.has(selection)) {
             operationIds.push(operationId);
-            promises.push(wsClient.unsubscribe(operationId, true));
+            promises.push(wsClient.unsubscribe(operationId));
             SubscriptionsSelections.delete(operationId);
             continue checkOperations;
           }


### PR DESCRIPTION
This makes the subscription client properly handle multiple components, that subscribe to the same operation.