### PR TITLE
chore(docs): add missing package

### DIFF
--- a/internal/website/docs/getting-started.mdx
+++ b/internal/website/docs/getting-started.mdx
@@ -7,7 +7,7 @@ title: Getting started
 
 1. Go to the root of your project, and run:
 
-<PackageInstall packages={['gqty graphql', '-D @gqty/cli']} />
+<PackageInstall packages={['gqty graphql @gqty/react', '-D @gqty/cli']} />
 
 2. Next, add a `script` field to your package.json:
    ```json
@@ -29,17 +29,17 @@ The default config should look something like this:
 
 ```js
 /**
-* @type {import("@gqty/cli").GQtyConfig}
-*/
+ * @type {import("@gqty/cli").GQtyConfig}
+ */
 const config = {
- react: true,
- scalarTypes: { DateTime: 'string' },
- introspection: {
-   endpoint: 'SPECIFY_ENDPOINT_OR_SCHEMA_FILE_PATH_HERE',
-   headers: {},
- },
- destination: './src/gqty/index.ts',
- subscriptions: false,
+  react: true,
+  scalarTypes: { DateTime: 'string' },
+  introspection: {
+    endpoint: 'SPECIFY_ENDPOINT_OR_SCHEMA_FILE_PATH_HERE',
+    headers: {},
+  },
+  destination: './src/gqty/index.ts',
+  subscriptions: false,
 };
 
 module.exports = config;


### PR DESCRIPTION
Fixes #1257

Because of the default config value of `react: true`, ultimately I want to stay framework agnostic.

We may have to split this page for each framework in the future, but let's make this a docs change instead of a major release (change of default value) for the moment.