### PR TITLE
chore(ci): update github actions

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -20,7 +20,8 @@ jobs:
       - uses: pnpm/action-setup@v2.2.4
         with:
           version: ^7.1.1
-      - name: Setup Node.js 16.x
+
+      - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: 16

--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js 16.x
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 16
           cache: 'pnpm'
 
       - name: Setup NPM credentials

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,10 +23,11 @@ jobs:
       - uses: pnpm/action-setup@v2.2.4
         with:
           version: ^7.1.1
+
       - name: Setup Node.js 16.x
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 16
           cache: 'pnpm'
 
       - name: Install Dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,7 @@ on:
       - '.husky/**'
     branches:
       - main
+
 jobs:
   release:
     name: Release
@@ -19,20 +20,16 @@ jobs:
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
-
       - uses: pnpm/action-setup@v2.2.4
         with:
           version: ^7.1.1
-
-      - name: Setup Node.js 16.x
+      - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: 'pnpm'
-
       - name: Install Dependencies
         run: pnpm install
-
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1


### PR DESCRIPTION
1. [x] Upgrade to `actions/setup-node@v3`
2. [ ] Replace the archived `kamilkisiela/release-canary` with the official `changesets/action@v1`

Closes #1343 