### PR TITLE
fix(tests): node-v18

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [14, 16]
+        node-version: [14, 16, 18]
         os: [ubuntu-latest]
     steps:
       - name: Checkout code

--- a/packages/gqty/test/ssr.test.tsx
+++ b/packages/gqty/test/ssr.test.tsx
@@ -113,7 +113,7 @@ describe('server side rendering', () => {
       .mockImplementation((message) => {
         expect(message).toEqual(
           SyntaxError(
-            semver.gte(process.version, '18.0.0')
+            semver.gt(process.version, '19.0.0')
               ? `Unexpected token 'i', "invalid" is not valid JSON`
               : `Unexpected token i in JSON at position 0`
           )


### PR DESCRIPTION
I should really check v8 version in `process.versions.v8`, but this should also do the job so I don't bother.