### PR TITLE
feat(packages/react): add $refetch to useQuery()

### DIFF
--- a/.changeset/tricky-bats-glow.md
+++ b/.changeset/tricky-bats-glow.md
@@ -1,0 +1,5 @@
+---
+'@gqty/react': minor
+---
+
+feat(packages/react): $refetch in useQuery()

--- a/packages/gqty/src/Accessor/index.ts
+++ b/packages/gqty/src/Accessor/index.ts
@@ -639,8 +639,7 @@ export function createAccessorCreators<
                    * and the __typename doesn't correspond to the target object type
                    */
                   if (
-                    // SelectionType.Subscription === 2
-                    selection.type === 2 ||
+                    selection.type === SelectionType.Subscription ||
                     (!isUnionWithDifferentTypeResult &&
                       (schedulerClientCache !== innerState.clientCache ||
                         !schedulerErrorsMap.has(selection)))
@@ -652,8 +651,7 @@ export function createAccessorCreators<
                   return isArray ? emptyScalarArray : undefined;
                 } else if (
                   !innerState.allowCache ||
-                  // SelectionType.Subscription === 2
-                  selection.type === 2
+                  selection.type === SelectionType.Subscription
                 ) {
                   // Or if you are making the network fetch always
                   interceptorManager.addSelection(selection);

--- a/packages/gqty/src/Client/client.ts
+++ b/packages/gqty/src/Client/client.ts
@@ -316,13 +316,10 @@ export function createClient<
     try {
       await resolvePromise;
     } catch (error: any) {
-      /* istanbul ignore else */
-      if (resolvingPromise) {
-        resolvingPromise.resolve({
-          error,
-          selections,
-        });
-      }
+      resolvingPromise?.resolve({
+        error,
+        selections,
+      });
     }
   }
 

--- a/packages/gqty/src/Client/resolvers.ts
+++ b/packages/gqty/src/Client/resolvers.ts
@@ -194,7 +194,7 @@ export interface BuildAndFetchSelections {
     cache?: CacheInstance,
     options?: FetchResolveOptions,
     lastTry?: boolean | undefined
-  ): Promise<TData | null | undefined>;
+  ): Promise<TData | undefined>;
 }
 
 export interface ResolveSelections {
@@ -533,7 +533,7 @@ export function createResolvers(
     cache: CacheInstance = innerState.clientCache,
     options: FetchResolveOptions = {},
     lastTry?: boolean
-  ): Promise<TData | null | undefined> {
+  ) {
     if (!selections) return;
 
     const isLastTry =

--- a/packages/gqty/src/Events/index.ts
+++ b/packages/gqty/src/Events/index.ts
@@ -31,38 +31,38 @@ interface OnCacheChangeEventFn {
 export class EventHandler {
   public hasFetchSubscribers = false;
   private onFetchListeners = new Set<OnFetchEventFn>();
-
   private onCacheChangeListeners = new Set<OnCacheChangeEventFn>();
 
   public sendCacheChange(data: CacheChangeEventData) {
-    for (const listener of this.onCacheChangeListeners) listener(data);
+    for (const listener of this.onCacheChangeListeners) {
+      listener(data);
+    }
   }
 
   public sendFetchPromise(
     data: Promise<FetchEventData>,
     selections: Selection[]
   ) {
-    for (const listener of this.onFetchListeners) listener(data, selections);
+    for (const listener of this.onFetchListeners) {
+      listener(data, selections);
+    }
   }
 
   public onCacheChangeSubscribe(fn: OnCacheChangeEventFn) {
-    const self = this;
+    this.onCacheChangeListeners.add(fn);
 
-    self.onCacheChangeListeners.add(fn);
-
-    return function unsubscribe() {
-      self.onCacheChangeListeners.delete(fn);
+    return () => {
+      this.onCacheChangeListeners.delete(fn);
     };
   }
 
   public onFetchSubscribe(fn: OnFetchEventFn) {
-    const self = this;
+    this.onFetchListeners.add(fn);
+    this.hasFetchSubscribers = this.onFetchListeners.size > 0;
 
-    self.hasFetchSubscribers = Boolean(self.onFetchListeners.add(fn).size);
-
-    return function unsubscribe() {
-      self.onFetchListeners.delete(fn);
-      self.hasFetchSubscribers = Boolean(self.onFetchListeners.size);
+    return () => {
+      this.onFetchListeners.delete(fn);
+      this.hasFetchSubscribers = this.onFetchListeners.size > 0;
     };
   }
 }

--- a/packages/gqty/src/Helpers/refetch.ts
+++ b/packages/gqty/src/Helpers/refetch.ts
@@ -1,5 +1,5 @@
 import type { InnerClientState } from '../Client/client';
-import type { InlineResolveOptions, Resolvers } from '../Client/resolvers';
+import type { Resolvers } from '../Client/resolvers';
 
 export function isFunction<T>(v: T | (() => T)): v is () => T {
   return typeof v === 'function';
@@ -16,13 +16,9 @@ export function createRefetch(
 ): Refetch {
   const { accessorCache } = innerState;
 
-  const inlineResolveRefetch: InlineResolveOptions<unknown> = {
-    refetch: true,
-  };
-
   async function refetch<T = undefined | void>(refetchArg: T | (() => T)) {
     if (isFunction(refetchArg))
-      return inlineResolved(refetchArg, inlineResolveRefetch);
+      return inlineResolved(refetchArg, { refetch: true });
 
     if (accessorCache.isProxy(refetchArg)) {
       const selectionSet = accessorCache.getSelectionSetHistory(refetchArg);

--- a/packages/gqty/src/Interceptor/index.ts
+++ b/packages/gqty/src/Interceptor/index.ts
@@ -61,11 +61,13 @@ export function createInterceptorManager(): InterceptorManager {
   function createInterceptor() {
     const interceptor = new Interceptor();
     interceptors.add(interceptor);
+    // console.debug('+ interceptor', interceptors.size);
     return interceptor;
   }
 
   function removeInterceptor(interceptor: Interceptor) {
     interceptors.delete(interceptor);
+    // console.debug('- interceptor', interceptors.size);
   }
 
   function addSelection(selection: Selection) {

--- a/packages/react/src/client.ts
+++ b/packages/react/src/client.ts
@@ -23,14 +23,14 @@ import {
   UseSubscription,
 } from './subscription/useSubscription';
 
-import type { RetryOptions, GQtyClient } from 'gqty';
+import type { GQtyClient, RetryOptions } from 'gqty';
 import type { FetchPolicy } from './common';
-import type { ReactClientOptionsWithDefaults } from './utils';
 import {
   createUsePaginatedQuery,
   PaginatedQueryFetchPolicy,
   UsePaginatedQuery,
 } from './query/usePaginatedQuery';
+import type { ReactClientOptionsWithDefaults } from './utils';
 
 export interface ReactClientDefaults {
   /**
@@ -227,19 +227,6 @@ export function createReactClient<
     defaults,
   });
 
-  const state = new Proxy(
-    {
-      isLoading: false,
-    },
-    {
-      get(target, key, receiver) {
-        if (key === 'isLoading') return Boolean(client.scheduler.resolving);
-
-        return Reflect.get(target, key, receiver);
-      },
-    }
-  );
-
   const { prepareReactRender, useHydrateCache } = createSSRHelpers(
     client,
     opts
@@ -256,7 +243,11 @@ export function createReactClient<
     usePaginatedQuery: createUsePaginatedQuery<GeneratedSchema>(client, opts),
     useMutation: createUseMutation<GeneratedSchema>(client, opts),
     graphql: createGraphqlHOC(client, opts),
-    state,
+    state: {
+      get isLoading() {
+        return client.scheduler.resolving !== null;
+      },
+    },
     prepareReactRender,
     useHydrateCache,
     useMetaState: createUseMetaState(client),

--- a/packages/react/src/common.ts
+++ b/packages/react/src/common.ts
@@ -452,7 +452,11 @@ export function useInterceptSelections({
     },
   });
 
-  return { fetchingPromise, unsubscribe };
+  return {
+    fetchingPromise,
+    selections,
+    unsubscribe,
+  };
 }
 
 export function useSuspensePromise(optsRef: {

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -1,36 +1,9 @@
 export * from './client';
-
+export { coreHelpers, sortBy, uniqBy } from './common';
+export type { CoreHelpers, FetchPolicy, OnErrorHandler } from './common';
 export type {
-  UseQuery,
-  UseQueryOptions,
-  UseQueryState,
-  UseQueryReturnValue,
-} from './query/useQuery';
-export type { GraphQLHOC, GraphQLHOCOptions } from './query/hoc';
-export type {
-  UseTransactionQuery,
-  UseTransactionQueryOptions,
-  UseTransactionQueryState,
-} from './query/useTransactionQuery';
-export type {
-  LazyFetchPolicy,
-  UseLazyQuery,
-  UseLazyQueryOptions,
-  UseLazyQueryState,
-} from './query/useLazyQuery';
-export type {
-  UseRefetch,
-  UseRefetchOptions,
-  UseRefetchState,
-} from './query/useRefetch';
-export type {
-  PrepareQuery,
-  PreparedQuery,
-  UsePreparedQueryOptions,
-} from './query/preparedQuery';
-export type {
-  UseMetaState,
   MetaState,
+  UseMetaState,
   UseMetaStateOptions,
 } from './meta/useMetaState';
 export type {
@@ -38,21 +11,42 @@ export type {
   UseMutationOptions,
   UseMutationState,
 } from './mutation/useMutation';
-export type { UseSubscription } from './subscription/useSubscription';
+export type { GraphQLHOC, GraphQLHOCOptions } from './query/hoc';
 export type {
+  PreparedQuery,
+  PrepareQuery,
+  UsePreparedQueryOptions,
+} from './query/preparedQuery';
+export type {
+  LazyFetchPolicy,
+  UseLazyQuery,
+  UseLazyQueryOptions,
+  UseLazyQueryState,
+} from './query/useLazyQuery';
+export type {
+  FetchMoreCallbackArgs,
   PaginatedQueryFetchPolicy,
   UsePaginatedQuery,
-  FetchMoreCallbackArgs,
   UsePaginatedQueryData,
   UsePaginatedQueryMergeParams,
   UsePaginatedQueryOptions,
 } from './query/usePaginatedQuery';
 export type {
-  UseHydrateCache,
+  UseQuery,
+  UseQueryOptions,
+  UseQueryReturnValue,
+  UseQueryState,
+} from './query/useQuery';
+export type { UseRefetch, UseRefetchOptions } from './query/useRefetch';
+export type {
+  UseTransactionQuery,
+  UseTransactionQueryOptions,
+  UseTransactionQueryState,
+} from './query/useTransactionQuery';
+export type {
   PrepareReactRender,
   PropsWithServerCache,
+  UseHydrateCache,
   UseHydrateCacheOptions,
 } from './ssr/ssr';
-
-export type { OnErrorHandler, FetchPolicy, CoreHelpers } from './common';
-export { coreHelpers, uniqBy, sortBy } from './common';
+export type { UseSubscription } from './subscription/useSubscription';

--- a/packages/react/src/query/usePaginatedQuery.ts
+++ b/packages/react/src/query/usePaginatedQuery.ts
@@ -5,11 +5,11 @@ import {
   coreHelpers,
   CoreHelpers,
   FetchPolicy,
+  sortBy,
+  uniqBy,
   useSelectionsState,
   useSubscribeCacheChanges,
   useSuspensePromise,
-  uniqBy,
-  sortBy,
 } from '../common';
 import type { ReactClientOptionsWithDefaults } from '../utils';
 
@@ -228,7 +228,7 @@ export function createUsePaginatedQuery<
       React.Dispatch<UsePaginatedQueryReducerAction<TData>>
     ];
 
-    const hookSelections = useSelectionsState();
+    const selections = useSelectionsState();
 
     const stateRef = React.useRef(state);
     stateRef.current = state;
@@ -288,7 +288,7 @@ export function createUsePaginatedQuery<
 
         let incomingData = inlineResolved(resolvedFn, {
           onSelection(selection) {
-            hookSelections.add(selection);
+            selections.add(selection);
           },
           refetch,
           onCacheData(data) {
@@ -334,7 +334,7 @@ export function createUsePaginatedQuery<
     );
 
     useSubscribeCacheChanges({
-      hookSelections,
+      selections,
       eventHandler,
       onChange() {
         if (isMerging.current) return;

--- a/packages/react/src/query/useTransactionQuery.ts
+++ b/packages/react/src/query/useTransactionQuery.ts
@@ -182,7 +182,7 @@ export function createUseTransactionQuery<
         lazy: true,
       });
 
-      const hookSelections = useSelectionsState();
+      const selections = useSelectionsState();
 
       const resolveOptions = React.useMemo<ResolveOptions<TData>>(() => {
         return fetchPolicyDefaultResolveOptions(fetchPolicy);
@@ -237,7 +237,7 @@ export function createUseTransactionQuery<
             ...resolveOptions,
             ...resolveOptsArg,
             onSelection(selection) {
-              hookSelections.add(selection);
+              selections.add(selection);
             },
             onEmptyResolve() {
               instaResolved = true;
@@ -439,7 +439,7 @@ export function createUseTransactionQuery<
       ]);
 
       useSubscribeCacheChanges({
-        hookSelections,
+        selections,
         eventHandler,
         shouldSubscribe: fetchPolicy !== 'no-cache',
         onChange() {


### PR DESCRIPTION
This is the first step of a series of feature integration into `useQuery()`, adding `$refetch` allows the deprecation of `useRefetch()` in the next major.

Rationale behind cosmetic changes: Hoisting every single concept into it's own abstraction/implementation pairs doesn't favour small teams. Structuring them in a more literal/lexical sense allows a more "unit" mindset where you CMD + click, read and forget. I don't have to remember most of the types/abstractions to understand a function.

![image](https://user-images.githubusercontent.com/85772/215350555-3f9222a2-9d18-4fa8-b731-49fc9aca0430.png)
https://excalidraw.com/#room=c57aee69b01b478deede,TRUA1xJUS1De43xuNZGKjg