### PR TITLE
Skip canaries for bot PRs

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -8,6 +8,9 @@ on:
 jobs:
   release-canary:
     uses: the-guild-org/shared-config/.github/workflows/release-snapshot.yml@main
+    if:
+      ${{ github.actor != 'dependabot[bot]' && github.actor !=
+      'dependabot-preview[bot]' && github.actor != 'renovate[bot]' }}
     with:
       packageManager: pnpm
       npmTag: canary

--- a/packages/gqty/package.json
+++ b/packages/gqty/package.json
@@ -80,6 +80,7 @@
     "test-utils": "workspace:^0.1.0",
     "tsc-watch": "^6.0.0",
     "type-fest": "^3.9.0",
+    "typescript": "^5.4.5",
     "wait-on": "^7.0.1",
     "ws": "^8.13.0"
   },

--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = require('test-utils/jest.config.js').getConfig({
   setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect'],
+  setupFiles: ['./jest.setup.ts'],
   testEnvironment: 'jsdom',
 });

--- a/packages/react/jest.setup.ts
+++ b/packages/react/jest.setup.ts
@@ -1,0 +1,9 @@
+import { TextDecoder, TextEncoder } from 'util';
+
+Object.assign(globalThis, {
+  clearImmediate: () => {
+    // noop
+  },
+  TextEncoder,
+  TextDecoder,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -636,6 +636,9 @@ importers:
       type-fest:
         specifier: ^3.9.0
         version: 3.9.0
+      typescript:
+        specifier: ^5.4.5
+        version: 5.4.5
       wait-on:
         specifier: ^7.0.1
         version: 7.0.1


### PR DESCRIPTION
This pull request skips canaries for bot PRs to improve the efficiency of the CI workflow.