### PR TITLE
feat(packages/cli): add enumStyle config option

### DIFF
--- a/.changeset/soft-laws-appear.md
+++ b/.changeset/soft-laws-appear.md
@@ -1,0 +1,5 @@
+---
+'@gqty/cli': minor
+---
+
+Add `enumStyle` config option.

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -75,6 +75,7 @@ export const defaultConfig: SetRequired<
   destination: './src/gqty/index.ts',
   subscriptions: false,
   javascriptOutput: false,
+  enumStyle: 'enum',
   enumsAsStrings: false,
   enumsAsConst: false,
   preImport: '',

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -122,6 +122,7 @@ test('completely invalid config', () => {
               "destination": "./src/gqty/index.ts",
               "subscriptions": false,
               "javascriptOutput": false,
+              "enumStyle": "enum",
               "enumsAsStrings": false,
               "enumsAsConst": false,
               "preImport": ""


### PR DESCRIPTION
Adds `enumStyle` configuration option for mutually exclusive style of generated enum: `assertion`, `const`, `enum`, and `string`.

This deprecates existing config `enumsAsConst` and `enumsAsStrings`.