### PR TITLE
fix(package/cli): watch mode outside current working directory

### DIFF
--- a/.changeset/brown-beers-remain.md
+++ b/.changeset/brown-beers-remain.md
@@ -1,0 +1,5 @@
+---
+'@gqty/cli': patch
+---
+
+Allow watch targets above current working directory

--- a/packages/cli/src/commands/default.ts
+++ b/packages/cli/src/commands/default.ts
@@ -290,7 +290,7 @@ export const addCommand = (command: Command) => {
 
                   while (
                     lastIndex < prev.length &&
-                    prev[lastIndex] !== file[lastIndex]
+                    prev[lastIndex] === file[lastIndex]
                   ) {
                     lastIndex++;
                   }


### PR DESCRIPTION
Allows watch mode to watch outside of current working directory. Useful in monorepos.

This PR makes watch mode to watch recursively over a single file path that is the largest common file path prefix of file path endpoints and current working directory.