### PR TITLE
fix/data-can-be-null

### DIFF
--- a/packages/gqty/src/Helpers/fetcher.ts
+++ b/packages/gqty/src/Helpers/fetcher.ts
@@ -56,7 +56,7 @@ export const isExecutionResult = (input: unknown): input is ExecutionResult => {
 
   const value = input as Record<string, unknown>;
 
-  return 'data' in value || Array.isArray(value.errors);
+  return Boolean(value?.data) || Array.isArray(value.errors);
 };
 
 export const handleResponseErrors = async (result: ExecutionResult) => {


### PR DESCRIPTION
If, from GraphQL server we retrieve response like:
`{"errors":[{"message":"Unexpected error.","locations":[{"line":1,"column":7}],"path":["me"]}],"data":null}`
The previous code thought it was not an error and tried to read it. Because null is not an error, the whole console was red because of panic.