### PR TITLE
fix(gqty): onSubscribe for connected WebSockets

### DIFF
--- a/.changeset/breezy-apes-relax.md
+++ b/.changeset/breezy-apes-relax.md
@@ -1,0 +1,5 @@
+---
+'gqty': patch
+---
+
+fix(gqty): onSubscribe for connected WebSockets

--- a/examples/gnt/package.json
+++ b/examples/gnt/package.json
@@ -33,7 +33,7 @@
     "eslint-config-next": "^14.2.5",
     "postcss": "^8.4.41",
     "tailwindcss": "^3.4.9",
-    "typescript": "^5.5.4",
+    "typescript": "^5.6.3",
     "utf-8-validate": "^5.0.10"
   },
   "gqty": {

--- a/examples/solid/package.json
+++ b/examples/solid/package.json
@@ -23,7 +23,7 @@
     "postcss": "^8.4.38",
     "solid-devtools": "^0.29.2",
     "tailwindcss": "^3.4.3",
-    "typescript": "^5.3.3",
+    "typescript": "^5.6.3",
     "vite": "^5.4.3",
     "vite-plugin-solid": "^2.10.2"
   }

--- a/internal/test-utils/package.json
+++ b/internal/test-utils/package.json
@@ -56,7 +56,7 @@
     "@jest/types": "^29.6.3",
     "@types/node": "^20.14.15",
     "esbuild": "^0.23.0",
-    "typescript": "^5.5.4"
+    "typescript": "^5.6.3"
   },
   "peerDependencies": {
     "graphql": "*"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "tsx": "^4.19.0",
-    "typescript": "^5.5.4",
+    "typescript": "^5.6.3",
     "utf-8-validate": "^6.0.4",
     "wait-on": "^7.2.0"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -98,7 +98,7 @@
     "p-lazy": "^3.1.0",
     "test-utils": "workspace:^",
     "tmp-promise": "^3.0.3",
-    "typescript": "^5.5.4",
+    "typescript": "^5.6.3",
     "wait-on": "^7.2.0"
   },
   "peerDependencies": {

--- a/packages/gqty/package.json
+++ b/packages/gqty/package.json
@@ -104,7 +104,7 @@
     "test-utils": "workspace:^",
     "tsc-watch": "^6.2.0",
     "type-fest": "^4.24.0",
-    "typescript": "^5.5.4",
+    "typescript": "^5.6.3",
     "wait-on": "^7.2.0",
     "ws": "^8.18.0"
   },

--- a/packages/gqty/src/Cache/index.ts
+++ b/packages/gqty/src/Cache/index.ts
@@ -138,7 +138,10 @@ export class Cache {
   #data = new FrailMap<string, CacheDataContainer>();
 
   /** Look up table for normalized objects. */
-  #normalizedObjects = new Map<string, NormalizedObjectShell<CacheObject>>();
+  #normalizedObjects = new FrailMap<
+    string,
+    NormalizedObjectShell<CacheObject>
+  >();
 
   /** Temporary strong references for the WeakRefs in FrailMap. */
   #dataRefs = new Set<CacheDataContainer>();

--- a/packages/gqty/src/Cache/normalization.ts
+++ b/packages/gqty/src/Cache/normalization.ts
@@ -1,3 +1,4 @@
+import type { FrailMap } from 'frail-map';
 import type { CacheNode, CacheObject } from '.';
 import { GQtyError } from '../Error';
 import { deepAssign } from '../Utils';
@@ -22,7 +23,7 @@ const shells = new Set<NormalizedObjectShell>();
 
 export type NormalizatioOptions<TData extends CacheObject = CacheObject> =
   CacheNormalizationHandler & {
-    store: Map<string, NormalizedObjectShell<TData>>;
+    store: FrailMap<string, NormalizedObjectShell<TData>>;
   };
 
 /**

--- a/packages/gqty/src/Cache/query.ts
+++ b/packages/gqty/src/Cache/query.ts
@@ -17,11 +17,11 @@ const deduplicationCache = new WeakMap<
  *
  * After promise resolution, the hash is removed from the map.
  *
- * If the cache to omitted, a global cache will be used instead.
+ * If the `cache` argument is omitted, a global cache will be used instead.
  */
 export const dedupePromise = <
   TData = Record<string, unknown>,
-  TExtensions = Record<string, unknown>
+  TExtensions = Record<string, unknown>,
 >(
   cache: Cache | undefined,
   hash: string,

--- a/packages/gqty/src/Client/compat/resolved.ts
+++ b/packages/gqty/src/Client/compat/resolved.ts
@@ -5,7 +5,7 @@ import { updateCaches } from '../updateCaches';
 import type { CreateLegacyMethodOptions } from './client';
 import { convertSelection, type LegacySelection } from './selection';
 
-export interface LegacyFetchOptions extends Omit<RequestInit, 'body'> {}
+export type LegacyFetchOptions = Omit<RequestInit, 'body'>;
 
 export interface LegacyResolved {
   <T = unknown>(fn: () => T, opts?: LegacyResolveOptions<T>): Promise<T>;

--- a/packages/gqty/src/Client/subscriber.ts
+++ b/packages/gqty/src/Client/subscriber.ts
@@ -1,0 +1,52 @@
+import type { Client as SseClient } from 'graphql-sse';
+import type { Client as WsClient } from 'graphql-ws';
+
+export const isWsClient = (client?: SseClient | WsClient): client is WsClient =>
+  client !== undefined && typeof (client as WsClient).on === 'function';
+
+export type GQtyWsClient = WsClient & {
+  isOnline?: boolean;
+
+  /**
+   * Subscription listeners to be called when the client is online, or called
+   * immediately when the client is already online.
+   */
+  onSubscribe: (fn: () => void) => void;
+};
+
+/**
+ * Warning: If the WebSocket is already connected before this funciton is
+ * called, the `onSubscribe` will not be called until next connected event.
+ */
+export const createSubscriber = (input: WsClient): GQtyWsClient => {
+  const client = input as GQtyWsClient;
+
+  // Prevent double initialization
+  if (client.onSubscribe !== undefined) {
+    return client;
+  }
+
+  const listeners: Array<() => void> = [];
+
+  client.on('connected', () => {
+    if (!client.isOnline) {
+      client.isOnline = true;
+      listeners.forEach((fn) => fn());
+      listeners.length = 0;
+    }
+  });
+
+  client.on('closed', () => {
+    client.isOnline = false;
+  });
+
+  client.onSubscribe = (fn: () => void) => {
+    if (client.isOnline) {
+      fn();
+    } else {
+      listeners.push(fn);
+    }
+  };
+
+  return client;
+};

--- a/packages/gqty/src/QueryBuilder.ts
+++ b/packages/gqty/src/QueryBuilder.ts
@@ -92,7 +92,7 @@ export const buildQuery = (
         const key = s.alias ? `${s.alias}:${s.key}` : s.key;
         const input = s.input;
 
-        if (input) {
+        if (input && Object.keys(input.values).length > 0) {
           if (!inputDedupe.has(input)) {
             const queryInputs = Object.entries(input.values)
               .map(([key, value]) => {

--- a/packages/gqty/src/Utils/deferred.ts
+++ b/packages/gqty/src/Utils/deferred.ts
@@ -57,5 +57,8 @@ export const createDeferredIterator = <T>(): DeferredIterator<T> => {
     [Symbol.asyncIterator]() {
       return this;
     },
+    async [Symbol.asyncDispose]() {
+      await this.return();
+    },
   };
 };

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -50,7 +50,7 @@
     "gqty": "workspace:^",
     "jest": "^29.7.0",
     "test-utils": "workspace:^",
-    "typescript": "^5.5.4"
+    "typescript": "^5.6.3"
   },
   "peerDependencies": {
     "gqty": "workspace:^"

--- a/packages/react/src/client.ts
+++ b/packages/react/src/client.ts
@@ -183,9 +183,9 @@ export interface ReactClient<TSchema extends BaseGeneratedSchema> {
 export function createReactClient<TSchema extends BaseGeneratedSchema>(
   client: GQtyClient<TSchema>,
   {
+    defaults: { suspense = false } = {},
     defaults: {
       initialLoadingState = false,
-      suspense = false,
       transactionFetchPolicy = 'cache-first',
       lazyFetchPolicy = 'network-only',
       staleWhileRevalidate = false,

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -46,7 +46,7 @@
     "date-fns": "^3.6.0",
     "jsdom": "^24.0.0",
     "test-utils": "workspace:^",
-    "typescript": "^5.4.5",
+    "typescript": "^5.6.3",
     "vite": "^5.4.3",
     "vite-plugin-solid": "^2.10.2",
     "vitest": "^2.0.5"
@@ -64,7 +64,7 @@
     }
   },
   "engines": {
-    "node": ">=16 <=22"
+    "node": ">=16 <=23"
   },
   "publishConfig": {
     "directory": "dist"

--- a/packages/subscriptions/package.json
+++ b/packages/subscriptions/package.json
@@ -46,7 +46,7 @@
     "gqty": "workspace:^",
     "graphql": "^16.9.0",
     "test-utils": "workspace:^",
-    "typescript": "^5.5.4"
+    "typescript": "^5.6.3"
   },
   "peerDependencies": {
     "gqty": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,16 +31,16 @@ importers:
         version: 20.16.5
       bob-esbuild:
         specifier: ^4.0.3
-        version: 4.0.3(esbuild@0.23.1)(typescript@5.5.4)
+        version: 4.0.3(esbuild@0.23.1)(typescript@5.6.3)
       bob-esbuild-cli:
         specifier: ^4.0.0
         version: 4.0.0(bob-esbuild@4.0.3)
       bob-ts:
         specifier: ^4.1.1
-        version: 4.1.1(@types/node@20.16.5)(esbuild@0.23.1)(typescript@5.5.4)
+        version: 4.1.1(@types/node@20.16.5)(esbuild@0.23.1)(typescript@5.6.3)
       bob-tsm:
         specifier: ^1.1.2
-        version: 1.1.2(esbuild@0.23.1)(typescript@5.5.4)
+        version: 1.1.2(esbuild@0.23.1)(typescript@5.6.3)
       bufferutil:
         specifier: ^4.0.8
         version: 4.0.8
@@ -73,16 +73,16 @@ importers:
         version: 2.8.8
       ts-jest:
         specifier: ^29.2.5
-        version: 29.2.5(@babel/core@7.25.2)(esbuild@0.23.1)(jest@29.7.0)(typescript@5.5.4)
+        version: 29.2.5(@babel/core@7.25.2)(esbuild@0.23.1)(jest@29.7.0)(typescript@5.6.3)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@20.16.5)(typescript@5.5.4)
+        version: 10.9.2(@types/node@20.16.5)(typescript@5.6.3)
       tsx:
         specifier: ^4.19.0
         version: 4.19.0
       typescript:
-        specifier: ^5.5.4
-        version: 5.5.4
+        specifier: ^5.6.3
+        version: 5.6.3
       utf-8-validate:
         specifier: ^6.0.4
         version: 6.0.4
@@ -149,7 +149,7 @@ importers:
         version: 8.57.0
       eslint-config-next:
         specifier: ^14.2.5
-        version: 14.2.5(eslint@8.57.0)(typescript@5.5.4)
+        version: 14.2.5(eslint@8.57.0)(typescript@5.6.3)
       postcss:
         specifier: ^8.4.41
         version: 8.4.41
@@ -157,8 +157,8 @@ importers:
         specifier: ^3.4.9
         version: 3.4.9(ts-node@10.9.2)
       typescript:
-        specifier: ^5.5.4
-        version: 5.5.4
+        specifier: ^5.6.3
+        version: 5.6.3
       utf-8-validate:
         specifier: ^5.0.10
         version: 5.0.10
@@ -291,7 +291,7 @@ importers:
         version: 18.3.0
       bob-tsm:
         specifier: ^1.1.2
-        version: 1.1.2(esbuild@0.23.1)(typescript@5.5.4)
+        version: 1.1.2(esbuild@0.23.1)(typescript@5.6.3)
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
@@ -339,8 +339,8 @@ importers:
         specifier: ^3.4.3
         version: 3.4.9(ts-node@10.9.2)
       typescript:
-        specifier: ^5.3.3
-        version: 5.5.4
+        specifier: ^5.6.3
+        version: 5.6.3
       vite:
         specifier: ^5.4.3
         version: 5.4.6(@types/node@20.16.5)
@@ -455,8 +455,8 @@ importers:
         specifier: ^0.23.0
         version: 0.23.0
       typescript:
-        specifier: ^5.5.4
-        version: 5.5.4
+        specifier: ^5.6.3
+        version: 5.6.3
 
   packages/cli:
     dependencies:
@@ -489,7 +489,7 @@ importers:
         version: 12.1.0
       cosmiconfig:
         specifier: ^9.0.0
-        version: 9.0.0(typescript@5.5.4)
+        version: 9.0.0(typescript@5.6.3)
       cross-fetch:
         specifier: ^4.0.0
         version: 4.0.0
@@ -532,10 +532,10 @@ importers:
         version: 2.7.3
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.4.0
-        version: 8.4.0(@typescript-eslint/parser@8.4.0)(eslint@8.57.0)(typescript@5.5.4)
+        version: 8.4.0(@typescript-eslint/parser@8.4.0)(eslint@8.57.0)(typescript@5.6.3)
       '@typescript-eslint/parser':
         specifier: ^8.4.0
-        version: 8.4.0(eslint@8.57.0)(typescript@5.5.4)
+        version: 8.4.0(eslint@8.57.0)(typescript@5.6.3)
       eslint:
         specifier: ^8.57.0
         version: 8.57.0
@@ -552,8 +552,8 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       typescript:
-        specifier: ^5.5.4
-        version: 5.5.4
+        specifier: ^5.6.3
+        version: 5.6.3
       wait-on:
         specifier: ^7.2.0
         version: 7.2.0
@@ -609,10 +609,10 @@ importers:
         version: 8.5.12
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.4.0
-        version: 8.4.0(@typescript-eslint/parser@8.4.0)(eslint@8.57.0)(typescript@5.5.4)
+        version: 8.4.0(@typescript-eslint/parser@8.4.0)(eslint@8.57.0)(typescript@5.6.3)
       '@typescript-eslint/parser':
         specifier: ^8.4.0
-        version: 8.4.0(eslint@8.57.0)(typescript@5.5.4)
+        version: 8.4.0(eslint@8.57.0)(typescript@5.6.3)
       bob-esbuild-cli:
         specifier: ^4.0.0
         version: 4.0.0(bob-esbuild@4.0.3)
@@ -654,13 +654,13 @@ importers:
         version: link:../../internal/test-utils
       tsc-watch:
         specifier: ^6.2.0
-        version: 6.2.0(typescript@5.5.4)
+        version: 6.2.0(typescript@5.6.3)
       type-fest:
         specifier: ^4.24.0
         version: 4.24.0
       typescript:
-        specifier: ^5.5.4
-        version: 5.5.4
+        specifier: ^5.6.3
+        version: 5.6.3
       wait-on:
         specifier: ^7.2.0
         version: 7.2.0
@@ -691,8 +691,8 @@ importers:
         specifier: workspace:^
         version: link:../../internal/test-utils
       typescript:
-        specifier: ^5.5.4
-        version: 5.5.4
+        specifier: ^5.6.3
+        version: 5.6.3
     publishDirectory: dist
 
   packages/react:
@@ -754,10 +754,10 @@ importers:
         version: 0.0.6
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.4.0
-        version: 8.4.0(@typescript-eslint/parser@8.4.0)(eslint@8.57.0)(typescript@5.6.2)
+        version: 8.4.0(@typescript-eslint/parser@8.4.0)(eslint@8.57.0)(typescript@5.6.3)
       '@typescript-eslint/parser':
         specifier: ^8.4.0
-        version: 8.4.0(eslint@8.57.0)(typescript@5.6.2)
+        version: 8.4.0(eslint@8.57.0)(typescript@5.6.3)
       eslint:
         specifier: ^8.57.0
         version: 8.57.0
@@ -799,7 +799,7 @@ importers:
         version: 4.24.0
       typescript-eslint:
         specifier: ^8.4.0
-        version: 8.4.0(eslint@8.57.0)(typescript@5.6.2)
+        version: 8.4.0(eslint@8.57.0)(typescript@5.6.3)
     publishDirectory: dist
 
   packages/solid:
@@ -839,8 +839,8 @@ importers:
         specifier: workspace:^
         version: link:../../internal/test-utils
       typescript:
-        specifier: ^5.4.5
-        version: 5.5.4
+        specifier: ^5.6.3
+        version: 5.6.3
       vite:
         specifier: ^5.4.3
         version: 5.4.6(@types/node@20.16.5)
@@ -880,8 +880,8 @@ importers:
         specifier: workspace:^
         version: link:../../internal/test-utils
       typescript:
-        specifier: ^5.5.4
-        version: 5.5.4
+        specifier: ^5.6.3
+        version: 5.6.3
     publishDirectory: dist
 
 packages:
@@ -7351,7 +7351,7 @@ packages:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  /@typescript-eslint/eslint-plugin@8.4.0(@typescript-eslint/parser@8.4.0)(eslint@8.57.0)(typescript@5.5.4):
+  /@typescript-eslint/eslint-plugin@8.4.0(@typescript-eslint/parser@8.4.0)(eslint@8.57.0)(typescript@5.6.3):
     resolution: {integrity: sha512-rg8LGdv7ri3oAlenMACk9e+AR4wUV0yrrG+XKsGKOK0EVgeEDqurkXMPILG2836fW4ibokTB5v4b6Z9+GYQDEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
@@ -7363,49 +7363,22 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 8.4.0(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/parser': 8.4.0(eslint@8.57.0)(typescript@5.6.3)
       '@typescript-eslint/scope-manager': 8.4.0
-      '@typescript-eslint/type-utils': 8.4.0(eslint@8.57.0)(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.4.0(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/type-utils': 8.4.0(eslint@8.57.0)(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.4.0(eslint@8.57.0)(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 8.4.0
       eslint: 8.57.0
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 1.3.0(typescript@5.5.4)
-      typescript: 5.5.4
+      ts-api-utils: 1.3.0(typescript@5.6.3)
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin@8.4.0(@typescript-eslint/parser@8.4.0)(eslint@8.57.0)(typescript@5.6.2):
-    resolution: {integrity: sha512-rg8LGdv7ri3oAlenMACk9e+AR4wUV0yrrG+XKsGKOK0EVgeEDqurkXMPILG2836fW4ibokTB5v4b6Z9+GYQDEw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^8.0.0 || ^8.0.0-alpha.0
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 8.4.0(eslint@8.57.0)(typescript@5.6.2)
-      '@typescript-eslint/scope-manager': 8.4.0
-      '@typescript-eslint/type-utils': 8.4.0(eslint@8.57.0)(typescript@5.6.2)
-      '@typescript-eslint/utils': 8.4.0(eslint@8.57.0)(typescript@5.6.2)
-      '@typescript-eslint/visitor-keys': 8.4.0
-      eslint: 8.57.0
-      graphemer: 1.4.0
-      ignore: 5.3.2
-      natural-compare: 1.4.0
-      ts-api-utils: 1.3.0(typescript@5.6.2)
-      typescript: 5.6.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.5.4):
+  /@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.6.3):
     resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -7417,15 +7390,15 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.5.4)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.6.3)
       debug: 4.3.4
       eslint: 8.57.0
-      typescript: 5.5.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@8.4.0(eslint@8.57.0)(typescript@5.5.4):
+  /@typescript-eslint/parser@8.4.0(eslint@8.57.0)(typescript@5.6.3):
     resolution: {integrity: sha512-NHgWmKSgJk5K9N16GIhQ4jSobBoJwrmURaLErad0qlLjrpP5bECYg+wxVTGlGZmJbU03jj/dfnb6V9bw+5icsA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
@@ -7437,32 +7410,11 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 8.4.0
       '@typescript-eslint/types': 8.4.0
-      '@typescript-eslint/typescript-estree': 8.4.0(typescript@5.5.4)
+      '@typescript-eslint/typescript-estree': 8.4.0(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 8.4.0
       debug: 4.3.6
       eslint: 8.57.0
-      typescript: 5.5.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/parser@8.4.0(eslint@8.57.0)(typescript@5.6.2):
-    resolution: {integrity: sha512-NHgWmKSgJk5K9N16GIhQ4jSobBoJwrmURaLErad0qlLjrpP5bECYg+wxVTGlGZmJbU03jj/dfnb6V9bw+5icsA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 8.4.0
-      '@typescript-eslint/types': 8.4.0
-      '@typescript-eslint/typescript-estree': 8.4.0(typescript@5.6.2)
-      '@typescript-eslint/visitor-keys': 8.4.0
-      debug: 4.3.6
-      eslint: 8.57.0
-      typescript: 5.6.2
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7483,7 +7435,7 @@ packages:
       '@typescript-eslint/visitor-keys': 8.4.0
     dev: true
 
-  /@typescript-eslint/type-utils@8.4.0(eslint@8.57.0)(typescript@5.5.4):
+  /@typescript-eslint/type-utils@8.4.0(eslint@8.57.0)(typescript@5.6.3):
     resolution: {integrity: sha512-pu2PAmNrl9KX6TtirVOrbLPLwDmASpZhK/XU7WvoKoCUkdtq9zF7qQ7gna0GBZFN0hci0vHaSusiL2WpsQk37A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
@@ -7492,30 +7444,11 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.4.0(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.4.0(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/typescript-estree': 8.4.0(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.4.0(eslint@8.57.0)(typescript@5.6.3)
       debug: 4.3.6
-      ts-api-utils: 1.3.0(typescript@5.5.4)
-      typescript: 5.5.4
-    transitivePeerDependencies:
-      - eslint
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/type-utils@8.4.0(eslint@8.57.0)(typescript@5.6.2):
-    resolution: {integrity: sha512-pu2PAmNrl9KX6TtirVOrbLPLwDmASpZhK/XU7WvoKoCUkdtq9zF7qQ7gna0GBZFN0hci0vHaSusiL2WpsQk37A==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/typescript-estree': 8.4.0(typescript@5.6.2)
-      '@typescript-eslint/utils': 8.4.0(eslint@8.57.0)(typescript@5.6.2)
-      debug: 4.3.6
-      ts-api-utils: 1.3.0(typescript@5.6.2)
-      typescript: 5.6.2
+      ts-api-utils: 1.3.0(typescript@5.6.3)
+      typescript: 5.6.3
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -7531,7 +7464,7 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.5.4):
+  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.6.3):
     resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -7546,13 +7479,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.3
-      tsutils: 3.21.0(typescript@5.5.4)
-      typescript: 5.5.4
+      tsutils: 3.21.0(typescript@5.6.3)
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree@8.4.0(typescript@5.5.4):
+  /@typescript-eslint/typescript-estree@8.4.0(typescript@5.6.3):
     resolution: {integrity: sha512-kJ2OIP4dQw5gdI4uXsaxUZHRwWAGpREJ9Zq6D5L0BweyOrWsL6Sz0YcAZGWhvKnH7fm1J5YFE1JrQL0c9dd53A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
@@ -7568,35 +7501,13 @@ packages:
       is-glob: 4.0.3
       minimatch: 9.0.4
       semver: 7.6.3
-      ts-api-utils: 1.3.0(typescript@5.5.4)
-      typescript: 5.5.4
+      ts-api-utils: 1.3.0(typescript@5.6.3)
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree@8.4.0(typescript@5.6.2):
-    resolution: {integrity: sha512-kJ2OIP4dQw5gdI4uXsaxUZHRwWAGpREJ9Zq6D5L0BweyOrWsL6Sz0YcAZGWhvKnH7fm1J5YFE1JrQL0c9dd53A==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 8.4.0
-      '@typescript-eslint/visitor-keys': 8.4.0
-      debug: 4.3.6
-      fast-glob: 3.3.2
-      is-glob: 4.0.3
-      minimatch: 9.0.4
-      semver: 7.6.3
-      ts-api-utils: 1.3.0(typescript@5.6.2)
-      typescript: 5.6.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/utils@8.4.0(eslint@8.57.0)(typescript@5.5.4):
+  /@typescript-eslint/utils@8.4.0(eslint@8.57.0)(typescript@5.6.3):
     resolution: {integrity: sha512-swULW8n1IKLjRAgciCkTCafyTHHfwVQFt8DovmaF69sKbOxTSFMmIZaSHjqO9i/RV0wIblaawhzvtva8Nmm7lQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
@@ -7605,23 +7516,7 @@ packages:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
       '@typescript-eslint/scope-manager': 8.4.0
       '@typescript-eslint/types': 8.4.0
-      '@typescript-eslint/typescript-estree': 8.4.0(typescript@5.5.4)
-      eslint: 8.57.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /@typescript-eslint/utils@8.4.0(eslint@8.57.0)(typescript@5.6.2):
-    resolution: {integrity: sha512-swULW8n1IKLjRAgciCkTCafyTHHfwVQFt8DovmaF69sKbOxTSFMmIZaSHjqO9i/RV0wIblaawhzvtva8Nmm7lQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
-      '@typescript-eslint/scope-manager': 8.4.0
-      '@typescript-eslint/types': 8.4.0
-      '@typescript-eslint/typescript-estree': 8.4.0(typescript@5.6.2)
+      '@typescript-eslint/typescript-estree': 8.4.0(typescript@5.6.3)
       eslint: 8.57.0
     transitivePeerDependencies:
       - supports-color
@@ -8511,7 +8406,7 @@ packages:
       bob-esbuild:
         optional: true
     dependencies:
-      bob-esbuild: 4.0.3(esbuild@0.23.1)(typescript@5.5.4)
+      bob-esbuild: 4.0.3(esbuild@0.23.1)(typescript@5.6.3)
       commander: 9.5.0
     dev: true
 
@@ -8531,7 +8426,7 @@ packages:
       rollup: 2.79.1
     dev: true
 
-  /bob-esbuild@4.0.3(esbuild@0.23.1)(typescript@5.5.4):
+  /bob-esbuild@4.0.3(esbuild@0.23.1)(typescript@5.6.3):
     resolution: {integrity: sha512-9AGuh6V5Whsditj5n2oJjWAvHwgadgD2HD0qZ4rEBwY9tpj8YbfYeiaXQQV9qJxwT9oUYOsQE53wPNYBFDIfJA==}
     peerDependencies:
       esbuild: '>=0.14.39'
@@ -8546,10 +8441,10 @@ packages:
       bob-esbuild-plugin: 4.0.0(esbuild@0.23.1)(rollup@2.79.1)
       esbuild: 0.23.1
       rollup: 2.79.1
-      typescript: 5.5.4
+      typescript: 5.6.3
     dev: true
 
-  /bob-ts@4.1.1(@types/node@20.16.5)(esbuild@0.23.1)(typescript@5.5.4):
+  /bob-ts@4.1.1(@types/node@20.16.5)(esbuild@0.23.1)(typescript@5.6.3):
     resolution: {integrity: sha512-lXvGGP46GSU10LMHB27Kq2PZl+DaK1L5geHxxzLw/QklEWnvfzLPJsH9YGvV9F4AdIGJp85FTC1xIfanwd3NbQ==}
     engines: {node: '>=14.13.1'}
     hasBin: true
@@ -8567,10 +8462,10 @@ packages:
       bob-esbuild-plugin: 4.0.0(esbuild@0.23.1)(rollup@2.79.1)
       esbuild: 0.23.1
       rollup: 2.79.1
-      typescript: 5.5.4
+      typescript: 5.6.3
     dev: true
 
-  /bob-tsm@1.1.2(esbuild@0.23.1)(typescript@5.5.4):
+  /bob-tsm@1.1.2(esbuild@0.23.1)(typescript@5.6.3):
     resolution: {integrity: sha512-5H6wIDpQTop5rt/5JRvtssmpiTkIqi1EBkpSy19GfReOed6QoeD+iJIRjNgyiI7ZsX1ogETxgN7KiW5Wx6pUEQ==}
     engines: {node: '>=14.13.1'}
     hasBin: true
@@ -8582,7 +8477,7 @@ packages:
         optional: true
     dependencies:
       esbuild: 0.23.1
-      typescript: 5.5.4
+      typescript: 5.6.3
     optionalDependencies:
       fsevents: 2.3.3
     dev: true
@@ -9092,7 +8987,7 @@ packages:
       yaml: 1.10.2
     dev: false
 
-  /cosmiconfig@9.0.0(typescript@5.5.4):
+  /cosmiconfig@9.0.0(typescript@5.6.3):
     resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -9105,7 +9000,7 @@ packages:
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
-      typescript: 5.5.4
+      typescript: 5.6.3
     dev: false
 
   /create-jest@29.7.0(@types/node@20.14.15)(ts-node@10.9.2):
@@ -9934,7 +9829,7 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /eslint-config-next@14.2.5(eslint@8.57.0)(typescript@5.5.4):
+  /eslint-config-next@14.2.5(eslint@8.57.0)(typescript@5.6.3):
     resolution: {integrity: sha512-zogs9zlOiZ7ka+wgUnmcM0KBEDjo4Jis7kxN1jvC0N4wynQ2MIx/KBkg4mVF63J5EK4W0QMCn7xO3vNisjaAoA==}
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0
@@ -9945,7 +9840,7 @@ packages:
     dependencies:
       '@next/eslint-plugin-next': 14.2.5
       '@rushstack/eslint-patch': 1.10.2
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.6.3)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
@@ -9953,7 +9848,7 @@ packages:
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.57.0)
       eslint-plugin-react: 7.34.1(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.57.0)
-      typescript: 5.5.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
@@ -10014,7 +9909,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.6.3)
       debug: 3.2.7
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
@@ -10033,7 +9928,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.6.3)
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
       array.prototype.flat: 1.3.2
@@ -11903,7 +11798,7 @@ packages:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.2(@types/node@20.16.5)(typescript@5.5.4)
+      ts-node: 10.9.2(@types/node@20.16.5)(typescript@5.6.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -11943,7 +11838,7 @@ packages:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.2(@types/node@20.16.5)(typescript@5.5.4)
+      ts-node: 10.9.2(@types/node@20.16.5)(typescript@5.6.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -11988,7 +11883,7 @@ packages:
       pretty-format: 30.0.0-alpha.6
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.2(@types/node@20.16.5)(typescript@5.5.4)
+      ts-node: 10.9.2(@types/node@20.16.5)(typescript@5.6.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -13875,7 +13770,7 @@ packages:
     dependencies:
       lilconfig: 2.1.0
       postcss: 8.4.41
-      ts-node: 10.9.2(@types/node@20.16.5)(typescript@5.5.4)
+      ts-node: 10.9.2(@types/node@20.16.5)(typescript@5.6.3)
       yaml: 2.3.1
     dev: true
 
@@ -15409,29 +15304,20 @@ packages:
     hasBin: true
     dev: true
 
-  /ts-api-utils@1.3.0(typescript@5.5.4):
+  /ts-api-utils@1.3.0(typescript@5.6.3):
     resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
     engines: {node: '>=16'}
     peerDependencies:
       typescript: '>=4.2.0'
     dependencies:
-      typescript: 5.5.4
-    dev: true
-
-  /ts-api-utils@1.3.0(typescript@5.6.2):
-    resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      typescript: '>=4.2.0'
-    dependencies:
-      typescript: 5.6.2
+      typescript: 5.6.3
     dev: true
 
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /ts-jest@29.2.5(@babel/core@7.25.2)(esbuild@0.23.1)(jest@29.7.0)(typescript@5.5.4):
+  /ts-jest@29.2.5(@babel/core@7.25.2)(esbuild@0.23.1)(jest@29.7.0)(typescript@5.6.3):
     resolution: {integrity: sha512-KD8zB2aAZrcKIdGk4OwpJggeLcH1FgrICqDSROWqlnJXGCXK4Mn6FcdK2B6670Xr73lHMG1kHw8R87A0ecZ+vA==}
     engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -15466,11 +15352,11 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.6.3
-      typescript: 5.5.4
+      typescript: 5.6.3
       yargs-parser: 21.1.1
     dev: true
 
-  /ts-node@10.9.2(@types/node@20.16.5)(typescript@5.5.4):
+  /ts-node@10.9.2(@types/node@20.16.5)(typescript@5.6.3):
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
     peerDependencies:
@@ -15496,11 +15382,11 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.5.4
+      typescript: 5.6.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  /tsc-watch@6.2.0(typescript@5.5.4):
+  /tsc-watch@6.2.0(typescript@5.6.3):
     resolution: {integrity: sha512-2LBhf9kjKXnz7KQ/puLHlozMzzUNHAdYBNMkg3eksQJ9GBAgMg8czznM83T5PmsoUvDnXzfIeQn2lNcIYDr8LA==}
     engines: {node: '>=12.12.0'}
     hasBin: true
@@ -15511,7 +15397,7 @@ packages:
       node-cleanup: 2.1.2
       ps-tree: 1.2.0
       string-argv: 0.3.1
-      typescript: 5.5.4
+      typescript: 5.6.3
     dev: true
 
   /tsconfig-paths@3.15.0:
@@ -15538,14 +15424,14 @@ packages:
   /tslib@2.6.3:
     resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
 
-  /tsutils@3.21.0(typescript@5.5.4):
+  /tsutils@3.21.0(typescript@5.6.3):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.5.4
+      typescript: 5.6.3
     dev: true
 
   /tsx@4.19.0:
@@ -15649,7 +15535,7 @@ packages:
       possible-typed-array-names: 1.0.0
     dev: true
 
-  /typescript-eslint@8.4.0(eslint@8.57.0)(typescript@5.6.2):
+  /typescript-eslint@8.4.0(eslint@8.57.0)(typescript@5.6.3):
     resolution: {integrity: sha512-67qoc3zQZe3CAkO0ua17+7aCLI0dU+sSQd1eKPGq06QE4rfQjstVXR6woHO5qQvGUa550NfGckT4tzh3b3c8Pw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
@@ -15658,25 +15544,19 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.4.0(@typescript-eslint/parser@8.4.0)(eslint@8.57.0)(typescript@5.6.2)
-      '@typescript-eslint/parser': 8.4.0(eslint@8.57.0)(typescript@5.6.2)
-      '@typescript-eslint/utils': 8.4.0(eslint@8.57.0)(typescript@5.6.2)
-      typescript: 5.6.2
+      '@typescript-eslint/eslint-plugin': 8.4.0(@typescript-eslint/parser@8.4.0)(eslint@8.57.0)(typescript@5.6.3)
+      '@typescript-eslint/parser': 8.4.0(eslint@8.57.0)(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.4.0(eslint@8.57.0)(typescript@5.6.3)
+      typescript: 5.6.3
     transitivePeerDependencies:
       - eslint
       - supports-color
     dev: true
 
-  /typescript@5.5.4:
-    resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
+  /typescript@5.6.3:
+    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
     engines: {node: '>=14.17'}
     hasBin: true
-
-  /typescript@5.6.2:
-    resolution: {integrity: sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-    dev: true
 
   /ua-parser-js@0.7.32:
     resolution: {integrity: sha512-f9BESNVhzlhEFf2CHMSj40NWOjYPl1YKYbrvIr/hFTDEmLq7SRbWvm7FcdcpCYT95zrOhC7gZSxjdnnTpBcwVw==}


### PR DESCRIPTION
# Summary

The `onSubscribe` option on the core API `subscribe()` is firing only on the first `connection_ack`, callbacks on subsequent subscriptions using the same WebSocket connection are unintentionally skipped.

## Expected Result

1. When a subscription triggers a lazy connection, `onSubscribe` is called when we receive `connection_ack`.
2. When a subscription happens on an existing connection, `onSubscribe` is called immediately.
3. When a subscription happens during a reconnection attempt, `onSubscribe` is called when the connection is established.