### PR TITLE
Make ohash a normal dependency

### DIFF
--- a/.changeset/fluffy-berries-yawn.md
+++ b/.changeset/fluffy-berries-yawn.md
@@ -1,0 +1,5 @@
+---
+'gqty': patch
+---
+
+mave ohash to normal dependency

--- a/packages/gqty/package.json
+++ b/packages/gqty/package.json
@@ -78,6 +78,7 @@
     "just-safe-get": "^4.2.0",
     "just-safe-set": "^4.2.1",
     "multidict": "^1.0.9",
+    "ohash": "^1.1.4",
     "p-defer": "^3.0.0"
   },
   "devDependencies": {
@@ -95,7 +96,6 @@
     "graphql-ws": "^5.16.2",
     "jest": "^30.0.0-alpha.7",
     "just-memoize": "^2.2.0",
-    "ohash": "^1.1.4",
     "p-lazy": "^3.1.0",
     "test-utils": "workspace:^",
     "tsc-watch": "^6.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -558,6 +558,9 @@ importers:
       multidict:
         specifier: ^1.0.9
         version: 1.0.9
+      ohash:
+        specifier: ^1.1.4
+        version: 1.1.4
       p-defer:
         specifier: ^3.0.0
         version: 3.0.0
@@ -601,9 +604,6 @@ importers:
       jest:
         specifier: ^30.0.0-alpha.7
         version: 30.0.0-alpha.7(@types/node@22.13.1)(ts-node@10.9.2)
-      ohash:
-        specifier: ^1.1.4
-        version: 1.1.4
       p-lazy:
         specifier: ^3.1.0
         version: 3.1.0
@@ -11708,7 +11708,7 @@ packages:
 
   /ohash@1.1.4:
     resolution: {integrity: sha512-FlDryZAahJmEF3VR3w1KogSEdWX3WhA5GPakFx4J81kEAiHyLMpdLLElS8n8dfNadMgAne/MywcvmogzscVt4g==}
-    dev: true
+    dev: false
 
   /on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}


### PR DESCRIPTION
`pnpm dlx` will only install the `dependencies` of the packages that it's running the command against, and not the `devDependencies`

<img width="1475" alt="image" src="https://github.com/user-attachments/assets/31e26d82-167d-4367-a146-2986f58746ed" />
