### PR TITLE
feat(package/react): Add react-native support

### DIFF
--- a/bob-esbuild.config.ts
+++ b/bob-esbuild.config.ts
@@ -8,6 +8,60 @@ export const config: import('bob-esbuild').BobConfig = {
     dirs: ['packages/*'],
   },
   verbose: true,
+  manualRewritePackageJson: {
+    // Keep the expo/metro-friendly condition order when the package.json is
+    // rewritten for publication. Otherwise the generated manifest puts the ESM
+    // entry first and native apps pull the web bundle.
+    '@gqty/react': (pkg) => {
+      const normalizePath = (value?: string) =>
+        value?.replace('./dist/', './');
+
+      const deriveNativePath = (value?: string) =>
+        normalizePath(value)?.replace(/(\.m?js)$/u, '.native$1');
+
+      const preserveOrder = (
+        entry: Record<string, unknown> | string | undefined
+      ) => {
+        if (entry == null || typeof entry === 'string') return entry;
+
+        const candidate =
+          (entry.require as string | undefined) ??
+          (entry.import as string | undefined);
+
+        const nativePath = deriveNativePath(candidate);
+
+        const orderedEntries: [string, unknown][] = [];
+
+        if (nativePath) orderedEntries.push(['react-native', nativePath]);
+
+        for (const [key, value] of Object.entries(entry)) {
+          if (key === 'react-native') continue;
+          orderedEntries.push([key, value]);
+        }
+
+        return Object.fromEntries(orderedEntries);
+      };
+
+      const rewrittenExports =
+        pkg.exports &&
+        Object.fromEntries(
+          Object.entries(pkg.exports).map(([key, value]) => [
+            key,
+            preserveOrder(value as any),
+          ])
+        );
+
+      const nativeMain = deriveNativePath(pkg.main);
+
+      return nativeMain || rewrittenExports
+        ? {
+            ...pkg,
+            ...(nativeMain ? { 'react-native': nativeMain } : null),
+            ...(rewrittenExports ? { exports: rewrittenExports } : null),
+          }
+        : pkg;
+    },
+  },
   esbuildPluginOptions: isCLIPackage
     ? {
         // Check https://github.com/evanw/esbuild/issues/1146

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -28,3 +28,15 @@ documentations!**
 
 Documentation, bug reports, pull requests, and other contributions are welcomed!
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) for more information.
+
+## React Native
+
+- The React bindings ship platform-specific entry points so Metro can resolve
+  React Native friendly implementations automatically; no `react-dom` dependency
+  is required.
+- `prepareReactRender` is a no-op on native targets. Server-rendering helpers
+  remain web-only, and hydration defaults to cache snapshots from client
+  renders.
+- Effects that previously relied on browser visibility and online events now
+  listen to `AppState` changes to refetch when the app returns to the
+  foreground.

--- a/packages/react/native-types/react-native.d.ts
+++ b/packages/react/native-types/react-native.d.ts
@@ -1,0 +1,11 @@
+declare module 'react-native' {
+  export type AppStateStatus = 'active' | 'background' | 'inactive' | 'unknown';
+
+  export const AppState: {
+    currentState: AppStateStatus;
+    addEventListener(
+      type: 'change',
+      listener: (status: AppStateStatus) => void
+    ): { remove(): void };
+  };
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -26,17 +26,26 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "react-native": "./dist/index.native.js",
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
     },
-    "./*": {
-      "types": "./dist/*.d.ts",
-      "import": "./dist/*.mjs",
-      "require": "./dist/*.js"
+    "./client": {
+      "types": "./dist/client.d.ts",
+      "react-native": "./dist/client.native.js",
+      "require": "./dist/client.js",
+      "import": "./dist/client.mjs"
+    },
+    "./ssr/ssr": {
+      "types": "./dist/ssr/ssr.d.ts",
+      "react-native": "./dist/ssr/ssr.native.js",
+      "require": "./dist/ssr/ssr.js",
+      "import": "./dist/ssr/ssr.mjs"
     }
   },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
+  "react-native": "dist/index.native.js",
   "typings": "dist/index.d.ts",
   "files": [
     "dist",
@@ -82,7 +91,6 @@
     ]
   },
   "dependencies": {
-    "@react-hookz/web": "^23.1.0",
     "multidict": "^1.0.9",
     "p-debounce": "^4.0.0",
     "p-defer": "^3.0.0",
@@ -134,6 +142,9 @@
       "optional": true
     },
     "graphql-ws": {
+      "optional": true
+    },
+    "react-dom": {
       "optional": true
     }
   },

--- a/packages/react/src/client.native.ts
+++ b/packages/react/src/client.native.ts
@@ -1,0 +1,145 @@
+import {
+  $meta,
+  type BaseGeneratedSchema,
+  type GQtyClient,
+  type RetryOptions,
+} from 'gqty';
+import { getActivePromises } from 'gqty/Cache/query';
+import type { LegacyFetchPolicy } from './common';
+import { createUseMetaState, type UseMetaState } from './meta/useMetaState';
+import { createUseMutation, type UseMutation } from './mutation/useMutation';
+import { createGraphqlHOC, type GraphQLHOC } from './query/hoc';
+import { createPrepareQuery, type PrepareQuery } from './query/preparedQuery';
+import {
+  createUseLazyQuery,
+  type LazyFetchPolicy,
+  type UseLazyQuery,
+} from './query/useLazyQuery';
+import {
+  createUsePaginatedQuery,
+  type PaginatedQueryFetchPolicy,
+  type UsePaginatedQuery,
+} from './query/usePaginatedQuery';
+import { createUseQuery, type UseQuery } from './query/useQuery';
+import { createUseRefetch, type UseRefetch } from './query/useRefetch';
+import {
+  createUseTransactionQuery,
+  type UseTransactionQuery,
+} from './query/useTransactionQuery';
+import {
+  createSSRHelpers,
+  type PrepareReactRender,
+  type UseHydrateCache,
+} from './ssr/ssr.native';
+import {
+  createUseSubscription,
+  type UseSubscription,
+} from './subscription/useSubscription';
+import type { ReactClientOptionsWithDefaults } from './utils';
+
+export interface ReactClientDefaults {
+  initialLoadingState?: boolean;
+  suspense?: boolean;
+  lazyQuerySuspense?: boolean;
+  transactionQuerySuspense?: boolean;
+  mutationSuspense?: boolean;
+  preparedSuspense?: boolean;
+  paginatedQuerySuspense?: boolean;
+  transactionFetchPolicy?: LegacyFetchPolicy;
+  lazyFetchPolicy?: LazyFetchPolicy;
+  paginatedQueryFetchPolicy?: PaginatedQueryFetchPolicy;
+  staleWhileRevalidate?: boolean;
+  retry?: RetryOptions;
+  refetchAfterHydrate?: boolean;
+}
+
+export interface CreateReactClientOptions {
+  defaults?: ReactClientDefaults;
+}
+
+export interface ReactClient<TSchema extends BaseGeneratedSchema> {
+  useQuery: UseQuery<TSchema>;
+  useRefetch: UseRefetch<TSchema>;
+  useLazyQuery: UseLazyQuery<TSchema>;
+  useTransactionQuery: UseTransactionQuery<TSchema>;
+  usePaginatedQuery: UsePaginatedQuery<TSchema>;
+  useMutation: UseMutation<TSchema>;
+  graphql: GraphQLHOC;
+  state: { isLoading: boolean };
+  prepareReactRender: PrepareReactRender;
+  useHydrateCache: UseHydrateCache;
+  useMetaState: UseMetaState;
+  useSubscription: UseSubscription<TSchema>;
+  prepareQuery: PrepareQuery<TSchema>;
+}
+
+export function createReactClient<TSchema extends BaseGeneratedSchema>(
+  client: GQtyClient<TSchema>,
+  {
+    defaults: { suspense = false } = {},
+    defaults: {
+      initialLoadingState = false,
+      transactionFetchPolicy = 'cache-first',
+      lazyFetchPolicy = 'network-only',
+      staleWhileRevalidate = false,
+      retry = true,
+      lazyQuerySuspense = false,
+      transactionQuerySuspense = suspense,
+      mutationSuspense = false,
+      preparedSuspense = suspense,
+      refetchAfterHydrate = false,
+      paginatedQueryFetchPolicy = 'cache-first',
+      paginatedQuerySuspense = suspense,
+    } = {},
+    ...options
+  }: CreateReactClientOptions = {}
+): ReactClient<TSchema> {
+  const opts: ReactClientOptionsWithDefaults = {
+    ...options,
+    defaults: {
+      initialLoadingState,
+      lazyFetchPolicy,
+      lazyQuerySuspense,
+      mutationSuspense,
+      paginatedQueryFetchPolicy,
+      paginatedQuerySuspense,
+      preparedSuspense,
+      refetchAfterHydrate,
+      retry,
+      staleWhileRevalidate,
+      suspense,
+      transactionFetchPolicy,
+      transactionQuerySuspense,
+    },
+  };
+
+  const { prepareReactRender, useHydrateCache } = createSSRHelpers(
+    client,
+    opts
+  );
+
+  const useQuery = createUseQuery<TSchema>(client, opts);
+
+  return {
+    useQuery,
+    useRefetch: createUseRefetch(client, opts),
+    useLazyQuery: createUseLazyQuery<TSchema>(client, opts),
+    useTransactionQuery: createUseTransactionQuery<TSchema>(useQuery, opts),
+    usePaginatedQuery: createUsePaginatedQuery<TSchema>(client, opts),
+    useMutation: createUseMutation<TSchema>(client, opts),
+    graphql: createGraphqlHOC(client, opts),
+    state: {
+      get isLoading() {
+        const cache = $meta(client.schema.query)?.context.cache;
+        const promises = cache && getActivePromises(cache);
+
+        return !!promises?.length;
+      },
+    },
+    prepareReactRender,
+    useHydrateCache,
+    useMetaState: createUseMetaState(),
+    useSubscription: createUseSubscription<TSchema>(client),
+    prepareQuery: createPrepareQuery<TSchema>(client, opts),
+  };
+}

--- a/packages/react/src/common.ts
+++ b/packages/react/src/common.ts
@@ -12,7 +12,9 @@ import {
 } from 'gqty';
 import * as React from 'react';
 
-export const IS_BROWSER = typeof window !== 'undefined';
+export const IS_BROWSER =
+  typeof window !== 'undefined' ||
+  globalThis.navigator?.product === 'ReactNative';
 
 export const useIsomorphicLayoutEffect = IS_BROWSER
   ? React.useLayoutEffect

--- a/packages/react/src/hooks.ts
+++ b/packages/react/src/hooks.ts
@@ -1,0 +1,128 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { DependencyList, EffectCallback } from 'react';
+
+export function useRerender() {
+  const [, setState] = useState(0);
+
+  return useCallback(() => {
+    setState((value) => (value + 1) % Number.MAX_SAFE_INTEGER);
+  }, []);
+}
+
+export function useSyncedRef<T>(value: T) {
+  const ref = useRef(value);
+  ref.current = value;
+
+  return useMemo(
+    () =>
+      Object.freeze({
+        get current() {
+          return ref.current;
+        },
+      }),
+    []
+  );
+}
+
+export function useUnmountEffect(effect: () => void) {
+  const effectRef = useSyncedRef(effect);
+
+  useEffect(
+    () => () => {
+      effectRef.current();
+    },
+    []
+  );
+}
+
+export function useThrottledCallback<T extends (...args: any[]) => any>(
+  callback: T,
+  deps: DependencyList,
+  delay: number,
+  noTrailing = false
+) {
+  const timeout = useRef<ReturnType<typeof setTimeout>>();
+  const lastCall = useRef<{
+    args: Parameters<T>;
+    this: ThisParameterType<T>;
+  }>();
+
+  useUnmountEffect(() => {
+    if (timeout.current !== undefined) {
+      clearTimeout(timeout.current);
+      timeout.current = undefined;
+    }
+  });
+
+  return useMemo(() => {
+    const execute = (context: ThisParameterType<T>, args: Parameters<T>) => {
+      lastCall.current = undefined;
+      callback.apply(context, args);
+      timeout.current = setTimeout(() => {
+        timeout.current = undefined;
+
+        if (!noTrailing && lastCall.current) {
+          execute(lastCall.current.this, lastCall.current.args);
+        }
+      }, delay);
+    };
+
+    const wrapped = function (
+      this: ThisParameterType<T>,
+      ...args: Parameters<T>
+    ) {
+      if (timeout.current !== undefined) {
+        lastCall.current = { args, this: this };
+        return;
+      }
+
+      execute(this, args);
+    } as T;
+
+    Object.defineProperties(wrapped, {
+      length: { value: callback.length },
+      name: { value: `${callback.name || 'anonymous'}__throttled__${delay}` },
+    });
+
+    return wrapped;
+  }, [callback, delay, noTrailing, ...deps]);
+}
+
+export function useIntervalEffect(callback: () => void, ms?: number) {
+  const cbRef = useSyncedRef(callback);
+
+  useEffect(() => {
+    if (!ms && ms !== 0) return;
+
+    const id = setInterval(() => {
+      cbRef.current();
+    }, ms);
+
+    return () => {
+      clearInterval(id);
+    };
+  }, [ms]);
+}
+
+export function usePrevious<T>(value: T) {
+  const prev = useRef<T>();
+
+  useEffect(() => {
+    prev.current = value;
+  });
+
+  return prev.current;
+}
+
+export function useUpdateEffect(effect: EffectCallback, deps?: DependencyList) {
+  const isFirstMount = useRef(true);
+
+  useEffect(() => {
+    if (isFirstMount.current) {
+      isFirstMount.current = false;
+      return;
+    }
+
+    return effect();
+  }, deps);
+}

--- a/packages/react/src/index.native.tsx
+++ b/packages/react/src/index.native.tsx
@@ -1,0 +1,52 @@
+export * from './client.native';
+export { coreHelpers, sortBy, uniqBy } from './common';
+export type { LegacyFetchPolicy, OnErrorHandler } from './common';
+export type {
+  MetaState,
+  UseMetaState,
+  UseMetaStateOptions,
+} from './meta/useMetaState';
+export type {
+  UseMutation,
+  UseMutationOptions,
+  UseMutationState,
+} from './mutation/useMutation';
+export type { GraphQLHOC, GraphQLHOCOptions } from './query/hoc';
+export type {
+  PrepareQuery,
+  PreparedQuery,
+  UsePreparedQueryOptions,
+} from './query/preparedQuery';
+export type {
+  LazyFetchPolicy,
+  UseLazyQuery,
+  UseLazyQueryOptions,
+  UseLazyQueryState,
+} from './query/useLazyQuery';
+export type {
+  FetchMoreCallbackArgs,
+  PaginatedQueryFetchPolicy,
+  UsePaginatedQuery,
+  UsePaginatedQueryData,
+  UsePaginatedQueryMergeParams,
+  UsePaginatedQueryOptions,
+} from './query/usePaginatedQuery';
+export type {
+  UseQuery,
+  UseQueryOptions,
+  UseQueryReturnValue,
+  UseQueryState,
+} from './query/useQuery';
+export type { UseRefetch, UseRefetchOptions } from './query/useRefetch';
+export type {
+  UseTransactionQuery,
+  UseTransactionQueryOptions,
+  UseTransactionQueryState,
+} from './query/useTransactionQuery';
+export type {
+  PrepareReactRender,
+  PropsWithServerCache,
+  UseHydrateCache,
+  UseHydrateCacheOptions,
+} from './ssr/ssr.native';
+export type { UseSubscription } from './subscription/useSubscription';

--- a/packages/react/src/meta/useMetaState.ts
+++ b/packages/react/src/meta/useMetaState.ts
@@ -1,4 +1,4 @@
-import { useRerender } from '@react-hookz/web';
+import { useRerender } from '../hooks';
 import { GQtyError, Selection, useMetaStateHack } from 'gqty';
 import * as React from 'react';
 import { useExtractedSelections, type SelectionsOrProxy } from '../common';

--- a/packages/react/src/query/hoc.tsx
+++ b/packages/react/src/query/hoc.tsx
@@ -1,4 +1,4 @@
-import { useRerender } from '@react-hookz/web';
+import { useRerender } from '../hooks';
 import type { BaseGeneratedSchema, GQtyClient } from 'gqty';
 import * as React from 'react';
 import type { OnErrorHandler } from '../common';

--- a/packages/react/src/query/useQuery.ts
+++ b/packages/react/src/query/useQuery.ts
@@ -3,7 +3,7 @@ import {
   usePrevious,
   useRerender,
   useUpdateEffect,
-} from '@react-hookz/web';
+} from '../hooks';
 import {
   GQtyError,
   prepass,

--- a/packages/react/src/query/useTransactionQuery.ts
+++ b/packages/react/src/query/useTransactionQuery.ts
@@ -1,4 +1,4 @@
-import { useUpdateEffect } from '@react-hookz/web';
+import { useUpdateEffect } from '../hooks';
 import {
   type BaseGeneratedSchema,
   type GQtyError,

--- a/packages/react/src/subscription/useSubscription.ts
+++ b/packages/react/src/subscription/useSubscription.ts
@@ -1,4 +1,4 @@
-import { useRerender, useThrottledCallback } from '@react-hookz/web';
+import { useRerender, useThrottledCallback } from '../hooks';
 import { GQtyError, type BaseGeneratedSchema, type GQtyClient } from 'gqty';
 import { useEffect, useMemo, useState } from 'react';
 

--- a/packages/react/src/useOnlineEffect.native.ts
+++ b/packages/react/src/useOnlineEffect.native.ts
@@ -1,0 +1,28 @@
+import { useEffect, type DependencyList } from 'react';
+import { AppState, type AppStateStatus } from 'react-native';
+
+export const useOnlineEffect = (
+  fn: (...args: unknown[]) => unknown,
+  deps?: DependencyList
+) => {
+  useEffect(() => {
+    let previousState: AppStateStatus = AppState.currentState;
+
+    const handleChange = (nextState: AppStateStatus) => {
+      if (
+        previousState.match(/inactive|background/) &&
+        nextState === 'active'
+      ) {
+        fn();
+      }
+
+      previousState = nextState;
+    };
+
+    const subscription = AppState.addEventListener('change', handleChange);
+
+    return () => {
+      subscription.remove();
+    };
+  }, deps);
+};

--- a/packages/react/src/useThrottledAsync.ts
+++ b/packages/react/src/useThrottledAsync.ts
@@ -1,4 +1,4 @@
-import { useSyncedRef } from '@react-hookz/web';
+import { useSyncedRef } from './hooks';
 import { useMemo, useRef, useState } from 'react';
 
 export type AsyncStatus = 'loading' | 'success' | 'error' | 'not-executed';

--- a/packages/react/src/useWindowFocusEffect.native.ts
+++ b/packages/react/src/useWindowFocusEffect.native.ts
@@ -1,0 +1,38 @@
+import { useEffect, type DependencyList } from 'react';
+import { AppState, type AppStateStatus } from 'react-native';
+
+export type UseFocusChangeEffectOptions = {
+  enabled?: boolean;
+};
+
+export const useWindowFocusEffect = (
+  fn: (...args: unknown[]) => unknown,
+  deps: DependencyList = [],
+  { enabled = true }: UseFocusChangeEffectOptions = {}
+) => {
+  useEffect(
+    () => {
+      if (!enabled) return;
+
+      let previousState: AppStateStatus = AppState.currentState;
+
+      const onChange = (nextState: AppStateStatus) => {
+        if (
+          previousState.match(/inactive|background/) &&
+          nextState === 'active'
+        ) {
+          fn();
+        }
+
+        previousState = nextState;
+      };
+
+      const subscription = AppState.addEventListener('change', onChange);
+
+      return () => {
+        subscription.remove();
+      };
+    },
+    deps.concat(fn, enabled)
+  );
+};

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,3 +1,7 @@
 {
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["./native-types/react-native"]
+  },
+  "include": ["src", "native-types"]
 }


### PR DESCRIPTION
I tried using gqty in react-native and ran into the issue that there are dependency pointing to react-dom, leading to an issue with the metro bundler pulling web resources. There where two dependencies that pull in react-dom, the hooks from `@react-hookz/web` and the ssr implementation using `react-dom/server`. 

This PR introduces react-native support for @gqty/react. I did the following updates:

* Added native entry points files like client.native.ts, index.native.tsx, ssr.native.ts, and native versions of the focus/online hooks so Metro resolves to RN-specific implementations that never import react-dom/server.
* Updated the build and the packages/react/package.json which now maps every export (., ./client, ./ssr/ssr) to the native bundle first and droped the wildcard ./*. bob-esbuild.config.ts rewrites dist/package.json so the published package keeps those native mappings at the top.
* Replaced `@react-hookz/web` with local hook helpers via hooks.ts (useRerender, useUpdateEffect, etc.) to avoid the peer dependency on react-dom. No behavioural change, just implementation detail. May need more testing. 
* Added a short “React Native” section to the README describing the limitations (SSR still web-only, effects use AppState). 

There are some risks in this approach as far as I can tell the removal of the wildcard could be a problem and would break anyone using `@gqty/react/*` imports. Also the custom implementation of the hooks maybe a risk. 

As an alternative I could also create a new `@gqty/react-native` package in order to keep the react package as is. There is some code duplication of course, it maybe possible to move certain things into a shared package but will take more time. 
