### PR TITLE
fix(react): resolve infinite Suspense retry loop on promise rejection

### DIFF
--- a/packages/react/src/query/suspense-resource.ts
+++ b/packages/react/src/query/suspense-resource.ts
@@ -1,0 +1,89 @@
+// 1. Define explicit interfaces for your return types
+export interface SuspenseResourceCache<Key, Value> {
+  get(key: Key): Value | undefined;
+  set(key: Key, value: Value): void;
+  has(key: Key): boolean;
+  clear(): void;
+  delete(key: Key): boolean;
+}
+
+export interface SuspenseResource<TResult> {
+  read(): TResult;
+}
+
+// 2. Cache Implementation
+export function createSuspenseResourceCache<
+  Key,
+  Value,
+>(): SuspenseResourceCache<Key, Value> {
+  const map = new Map<Key, Value>();
+
+  return {
+    get(key: Key) {
+      return map.get(key);
+    },
+    set(key: Key, value: Value) {
+      map.set(key, value);
+    },
+    has(key: Key) {
+      return map.has(key);
+    },
+    clear() {
+      map.clear();
+    },
+    delete(key: Key) {
+      return map.delete(key); // Map.delete returns a boolean
+    },
+  };
+}
+
+// 3. Resource Implementation
+export function createSuspenseResource<TResult>(
+  asyncFn: () => Promise<TResult>
+): SuspenseResource<TResult> {
+  let status: 'pending' | 'success' | 'error' = 'pending';
+  // It only holds the result or the error. The promise is stored separately.
+  let result: TResult | Error;
+
+  // The promise returned by .then() resolves to void.
+  // We save this to throw it so React Suspense can catch it.
+  const suspender: Promise<void> = asyncFn().then(
+    (data) => {
+      status = 'success';
+      result = data;
+    },
+    (err: unknown) => {
+      status = 'error';
+      result = err instanceof Error ? err : new Error(String(err));
+    }
+  );
+
+  return {
+    read(): TResult {
+      if (status === 'pending') {
+        throw suspender;
+      }
+      if (status === 'error') {
+        throw result;
+      }
+      // If it's not pending or error, it must be success, so it's safe to cast.
+      return result as TResult;
+    },
+  };
+}
+
+// 4. Getter Implementation
+export function getSuspenseResource<Key, TResult>(
+  cache: SuspenseResourceCache<Key, SuspenseResource<TResult>>,
+  key: Key,
+  asyncFn: () => Promise<TResult>
+): SuspenseResource<TResult> {
+  if (cache.has(key)) {
+    // We know it exists because of cache.has(), so we can safely use the non-null assertion (!)
+    return cache.get(key)!;
+  }
+
+  const resource = createSuspenseResource(asyncFn);
+  cache.set(key, resource);
+  return resource;
+}

--- a/packages/react/src/query/useQuery.ts
+++ b/packages/react/src/query/useQuery.ts
@@ -24,6 +24,11 @@ import { useOnlineEffect } from '../useOnlineEffect';
 import { useRenderSession } from '../useRenderSession';
 import { useWindowFocusEffect } from '../useWindowFocusEffect';
 import type { ReactClientOptionsWithDefaults } from '../utils';
+import {
+  createSuspenseResourceCache,
+  getSuspenseResource,
+  type SuspenseResource,
+} from './suspense-resource';
 
 export interface UseQueryPrepareHelpers<
   GeneratedSchema extends {
@@ -181,6 +186,20 @@ export const createUseQuery = <TSchema extends BaseGeneratedSchema>(
   // other contexts should also be included.
   const resolverStack = new ModifiedSet<ResolverParts>();
 
+  // Suspense Resource Cache, holds the suspense resource for each query.
+  // This is used when `suspense: true` and `prepare` are both active.
+  // We need a stable resource cache to ensure that we throw the same promise
+  // across renders, supporting both CSR and SSR.
+  // While `setState({ error })` might suffice for CSR, it fails on SSR because
+  // the state is lost during the retry, causing an infinite loop if the
+  // promise rejects. The stable cache ensures the error is correctly thrown
+  // and caught by ErrorBoundaries in all environments.
+  // ref: https://github.com/facebook/react/issues/17526
+  const suspenseResourceCache = createSuspenseResourceCache<
+    string,
+    SuspenseResource<any>
+  >();
+
   return ({
     extensions,
     fetchInBackground = false,
@@ -290,11 +309,37 @@ export const createUseQuery = <TSchema extends BaseGeneratedSchema>(
       // When using prepare with suspense, the promise should be thrown
       // immediately.
       if (context.shouldFetch && suspense) {
-        throw client.resolve(({ query }) => prepare({ prepass, query }), {
-          cachePolicy,
-          operationName,
-          retryPolicy,
-        });
+        // We create a unique hash for the current query based on the selections
+        // and operation parameters. This ensures that we can identify if we're
+        // fetching the same data across renders.
+        const queryHash = Array.from(selections)
+          .map((s) => s.cacheKeys.join('.'))
+          .sort()
+          .join('|');
+
+        const suspenseKey = `suspense-${
+          operationName || 'query'
+        }-${cachePolicy}-${queryHash}`;
+
+        // By using a resource cache, we ensure that we throw the same promise
+        // (the "resource") for the same query. This prevents React from
+        // entering an infinite loop of re-renders.
+        // Crucially, the resource tracks the promise state so that if it
+        // rejects, we throw the actual error, allowing it to be caught by
+        // an ErrorBoundary instead of silently failing and retrying forever.
+        const resource = getSuspenseResource(
+          suspenseResourceCache,
+          suspenseKey,
+          () => {
+            return client.resolve(({ query }) => prepare({ prepass, query }), {
+              cachePolicy,
+              operationName,
+              retryPolicy,
+            });
+          }
+        );
+
+        throw resource.read();
       }
     }
 


### PR DESCRIPTION
Introduce a stable resource cache for Suspense to ensure consistent
thrown promises across renders. This specifically addresses issues
when using `suspense: true` with the `prepare` helper.

The stable cache ensures the fix works in both CSR and SSR environments.
While a simple `setState({ error })` might suffice for CSR, it fails on
the server because state is lost during the retry phase. By caching the
resource, we guarantee that rejected promises are correctly thrown as
errors, allowing them to be caught by an ErrorBoundary instead of
triggering an infinite retry loop.

- Add `suspense-resource.ts` for managing stable Suspense resources.
- Update `useQuery` to utilize `suspenseResourceCache` for `prepare` calls.
- Add detailed comments on hashing, SSR state persistence, and error handling.