### PR TITLE
fix(gqty): resolve crash and redundant fetches during prepareReactRender

### DIFF
--- a/packages/gqty/src/Accessor/resolve.ts
+++ b/packages/gqty/src/Accessor/resolve.ts
@@ -89,7 +89,23 @@ export const resolve = (
     }
     // Trigger cached sub-selections for nullable object types.
     else {
-      context.select(selection);
+      let hasLeaf = false;
+
+      // GraphQL requires sub-selections for object types.
+      // If we just selected the parent (e.g. `nullFather`), it would generate an invalid query
+      // like `human { nullFather }` instead of `human { nullFather { name } }` if a fetch is triggered later.
+      for (const leaf of selection.getLeafNodes()) {
+        if (leaf !== selection) {
+          context.select(leaf, cache);
+          hasLeaf = true;
+        }
+      }
+
+      // If no sub-selections were cached (e.g. it was never accessed before),
+      // fallback to __typename so the GraphQL query is syntactically valid if fetched.
+      if (!hasLeaf) {
+        context.select(selection.getChild('__typename'), cache);
+      }
     }
 
     return null;
@@ -560,7 +576,24 @@ export const createArrayAccessor = (meta: Meta) => {
 
   // Trigger cached sub-selections for empty arrays.
   if (cache.data.length === 0) {
-    context.select(selection);
+    const { pureType } = parseSchemaType(meta.type.__type);
+    if (context.scalars[pureType]) {
+      context.select(selection, cache);
+    } else {
+      let hasLeaf = false;
+
+      // Ensure that an array of objects generates a valid GraphQL query with sub-selections.
+      for (const leaf of selection.getLeafNodes()) {
+        if (leaf !== selection) {
+          context.select(leaf, cache);
+          hasLeaf = true;
+        }
+      }
+
+      if (!hasLeaf) {
+        context.select(selection.getChild('__typename'), cache);
+      }
+    }
   }
 
   const proxy = new Proxy(cache.data, arrayProxyHandler);

--- a/packages/gqty/src/Cache/index.ts
+++ b/packages/gqty/src/Cache/index.ts
@@ -271,14 +271,13 @@ export class Cache {
           return node;
         });
 
+        const hasValue = (val: any): boolean => {
+          if (Array.isArray(val)) return val.some(hasValue);
+          return val !== undefined;
+        };
+
         // Notify and breaks when one of the path hits
-        if (
-          Array.isArray(node)
-            ? (node as unknown[])
-                .flat(Infinity)
-                .some((item) => item !== undefined)
-            : node !== undefined
-        ) {
+        if (hasValue(node)) {
           listeners.add(notify);
           break;
         }

--- a/packages/gqty/src/Client/compat/prepareRender.ts
+++ b/packages/gqty/src/Client/compat/prepareRender.ts
@@ -1,5 +1,6 @@
 import { toJSON } from 'flatted';
 import type { BaseGeneratedSchema } from '..';
+import { isSkeleton } from '../../Accessor/skeleton';
 import { Cache } from '../../Cache';
 import type { CacheSnapshot } from '../../Cache/persistence';
 import type { Selection, SelectionSnapshot } from '../../Selection';
@@ -97,7 +98,26 @@ export const createLegacyPrepareRender = <TSchema extends BaseGeneratedSchema>({
     // server side. Deferred fetches such as useLazyQuery and useMutation
     // also don't fire during SSR.
     await fetchSelections(
-      new Set([...selections].filter((s) => s.root.key !== 'subscription')),
+      new Set(
+        [...selections].filter((s) => {
+          if (s.root.key === 'subscription') return false;
+
+          // Skip selections that are already successfully loaded in the cache.
+          // This prevents redundant fetches at the end of SSR when `useQuery(suspense: true)`
+          // has already fetched and hydrated the cache for these selections.
+          const cacheKey = s.cacheKeys.join('.');
+          const dataContainer = cache.get(cacheKey);
+          const data = dataContainer?.data;
+
+          const hasMissing = (val: any): boolean => {
+            if (val === undefined || isSkeleton(val)) return true;
+            if (Array.isArray(val)) return val.some(hasMissing);
+            return false;
+          };
+
+          return hasMissing(data);
+        })
+      ),
       {
         cache,
         debugger: debug,

--- a/packages/gqty/src/Helpers/select.ts
+++ b/packages/gqty/src/Helpers/select.ts
@@ -22,7 +22,10 @@ export function select(
   }
   // Exit when there are still sub-paths but scalars are reached
   else if (probedNode == null || typeof probedNode !== 'object') {
-    return undefined;
+    // If the parent node is explicitly null, sub-properties are definitively null rather than missing.
+    // Returning `null` rather than `undefined` correctly signals to cache hydration checks that
+    // the value is fully resolved and not a cache miss.
+    return probedNode === null ? null : undefined;
   }
 
   if (Array.isArray(probedNode)) {

--- a/packages/gqty/test/accessor.test.ts
+++ b/packages/gqty/test/accessor.test.ts
@@ -1,5 +1,6 @@
 import { getArrayFields, GQtyError } from '../src';
 import { $meta, assignSelections, setCache } from '../src/Accessor';
+import { buildQuery } from '../src/QueryBuilder';
 import {
   createTestClient,
   expectConsoleWarn,
@@ -461,18 +462,18 @@ describe('mutate accessors', () => {
     humanHello.dogs = newDogs;
 
     expect(humanHello.dogs).toMatchInlineSnapshot(`
-     [
-       {
-         "__typename": "Dog",
-         "name": "zxc",
-         "owner": {
-           "dogs": [Circular],
-           "father": [Circular],
-           "name": "hello",
-         },
-       },
-     ]
-    `);
+           [
+             {
+               "__typename": "Dog",
+               "name": "zxc",
+               "owner": {
+                 "dogs": [Circular],
+                 "father": [Circular],
+                 "name": "hello",
+               },
+             },
+           ]
+        `);
 
     const dogs = await resolved(() => {
       return getArrayFields(query.dogs, 'name');
@@ -489,49 +490,71 @@ describe('mutate accessors', () => {
     } as unknown as Human);
 
     expect(owner).toMatchInlineSnapshot(`
-     {
-       "__typename": "Human",
-       "dogs": [
-         {
-           "__typename": "Dog",
-           "name": "zxc",
-           "owner": {
-             "dogs": [
-               [Circular],
-             ],
-             "father": [Circular],
-             "name": "hello",
-           },
-         },
-       ],
-       "father": {
-         "dogs": [
            {
-             "__typename": "Dog",
-             "name": "zxc",
-             "owner": [Circular],
-           },
-         ],
-         "father": [Circular],
-         "name": "hello",
-       },
-       "name": "ModifiedOwner",
-       "node": [],
-       "sons": [
-         {
-           "dogs": [
-             {
-               "__typename": "Dog",
-               "name": "zxc",
-               "owner": [Circular],
+             "__typename": "Human",
+             "dogs": [
+               {
+                 "__typename": "Dog",
+                 "name": "zxc",
+                 "owner": {
+                   "dogs": [
+                     [Circular],
+                   ],
+                   "father": [Circular],
+                   "name": "hello",
+                 },
+               },
+             ],
+             "father": {
+               "dogs": [
+                 {
+                   "__typename": "Dog",
+                   "name": "zxc",
+                   "owner": [Circular],
+                 },
+               ],
+               "father": [Circular],
+               "name": "hello",
              },
-           ],
-           "father": [Circular],
-           "name": "hello",
-         },
-       ],
-       "union": [],
-     }
-    `);
+             "name": "ModifiedOwner",
+             "node": [],
+             "sons": [
+               {
+                 "dogs": [
+                   {
+                     "__typename": "Dog",
+                     "name": "zxc",
+                     "owner": [Circular],
+                   },
+                 ],
+                 "father": [Circular],
+                 "name": "hello",
+               },
+             ],
+             "union": [],
+           }
+        `);
+  });
+  test('null object selection generates valid leaf node selection', async () => {
+    const { resolve } = await createTestClient();
+
+    const selections = new Set<any>();
+
+    await resolve(
+      ({ query }) => {
+        query.human({ name: 'A' })?.nullFather;
+      },
+      {
+        onSelect(selection) {
+          selections.add(selection);
+        },
+      }
+    );
+
+    const builtQuery = buildQuery(selections)[0]?.query;
+
+    expect(builtQuery).toMatchInlineSnapshot(
+      `"query($ee49e8:String){eefc62:human(name:$ee49e8){__typename id}}"`
+    );
   });
 });

--- a/packages/react/test/useQuery.test.tsx
+++ b/packages/react/test/useQuery.test.tsx
@@ -1,7 +1,13 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { Cache, type QueryPayload } from 'gqty';
-import { act } from 'react';
+import { ReadableStream } from 'node:stream/web';
+import React, { act, type FC } from 'react';
+
 import { createMockReactClient, createReactTestClient, sleep } from './utils';
+
+if (typeof global.ReadableStream === 'undefined') {
+  global.ReadableStream = ReadableStream as any;
+}
 
 describe('useQuery', () => {
   describe('isLoading', () => {
@@ -357,5 +363,116 @@ describe('useQuery', () => {
         "query($a16193:ID!){a7c8bb:pet(id:$a16193){__typename id owner{__typename id name}}now peoples{__typename id name}}",
       ]
     `);
+  });
+
+  it('should not fail during prepareReactRender when null objects are accessed', async () => {
+    const fetches: QueryPayload[] = [];
+    const { useQuery, prepareReactRender } = await createReactTestClient(
+      undefined,
+      async (payload) => {
+        fetches.push(payload);
+        const { client } = await createReactTestClient();
+        return client.query(payload.query, payload.variables);
+      }
+    );
+
+    const Human: FC = () => {
+      const data = useQuery({
+        suspense: true,
+        prepare(helpers) {
+          const human = helpers.query.human();
+          human.nullFather?.__typename;
+          human.nullFather?.id;
+          human.nullFather?.name;
+        },
+      });
+
+      return <div>{data.human().nullFather?.name ?? 'No father'}</div>;
+    };
+
+    await prepareReactRender(<Human />);
+
+    // Check if the prepare function was called
+    expect(fetches.length).toBe(1);
+    expect(fetches[0].query).toMatchInlineSnapshot(
+      `"query{human{__typename id nullFather{__typename id name}}}"`
+    );
+  });
+  it('should fetch again during prepareReactRender if JSX accesses fields not in prepare', async () => {
+    const fetches: QueryPayload[] = [];
+    const { useQuery, prepareReactRender } = await createReactTestClient(
+      undefined,
+      async (payload) => {
+        fetches.push(payload);
+        const { client } = await createReactTestClient();
+        return client.query(payload.query, payload.variables);
+      }
+    );
+
+    const Human: FC = () => {
+      const data = useQuery({
+        suspense: true,
+        prepare(helpers) {
+          helpers.query.human().name;
+        },
+      });
+
+      return (
+        <div>
+          {data.human().name}
+          {data.human().father?.name}
+        </div>
+      );
+    };
+
+    await prepareReactRender(<Human />);
+
+    expect(fetches.length).toBe(2);
+    expect(fetches[0].query).toMatchInlineSnapshot(
+      `"query{human{__typename id name}}"`
+    );
+    expect(fetches[1].query).toMatchInlineSnapshot(
+      `"query{human{father{__typename id name}}}"`
+    );
+  });
+  it('should fetch again during prepareReactRender if some array elements are missing fields in cache', async () => {
+    const fetches: QueryPayload[] = [];
+    const { useQuery, prepareReactRender, cache } = await createReactTestClient(
+      undefined,
+      async (payload) => {
+        fetches.push(payload);
+        const { client } = await createReactTestClient();
+        return client.query(payload.query, payload.variables);
+      }
+    );
+
+    // Partially hydrate the cache: dogs exist, but their names are missing
+    cache.set({
+      query: {
+        dogs: [
+          { __typename: 'Dog', id: '1' },
+          { __typename: 'Dog', id: '2' },
+        ],
+      },
+    });
+
+    const Dogs: FC = () => {
+      const data = useQuery({
+        suspense: true,
+      });
+
+      return (
+        <div>
+          {data.dogs.map((p) => (
+            <div key={p.id}>{p.name}</div>
+          ))}
+        </div>
+      );
+    };
+
+    await prepareReactRender(<Dogs />);
+
+    // It should have fetched the names
+    expect(fetches.some((f) => f.query.includes('name'))).toBe(true);
   });
 });


### PR DESCRIPTION
Improve SSR stability and performance by ensuring valid GraphQL generation for null objects and deduplicating fetches for already-cached data.

- Update `resolve.ts` to fallback to leaf nodes or `__typename` for null objects and empty arrays, preventing invalid GraphQL queries (e.g., `human { nullFather }`).
- Update `select.ts` to return `null` instead of `undefined` for sub-paths of explicitly null nodes, correctly identifying resolved states.
- Implement a robust cache-aware filter in `prepareRender.ts` to skip redundant fetches for data already hydrated in the cache.
- Optimize cache notification and preparation checks with recursive `hasValue` and `hasMissing` helpers, replacing inefficient `flat(Infinity)` calls.
- Add comprehensive test cases in `useQuery.test.tsx` covering null object access and partial cache hits in arrays during SSR.

Note: @vicary All newly added test cases were verified to fail prior to these changes, confirming the identified bugs. While all existing tests continue to pass, please review the implementation for any unintended side effects or if an alternative architectural approach is preferred.